### PR TITLE
Changed default SamplingInterval to reduce load on embedded servers

### DIFF
--- a/src/Opc.Ua.Publisher.Module/Module.cs
+++ b/src/Opc.Ua.Publisher.Module/Module.cs
@@ -369,7 +369,7 @@ namespace Opc.Ua.Publisher
                 monitoredItem.AttributeId = Attributes.Value;
                 monitoredItem.DisplayName = nodeDisplayName;
                 monitoredItem.MonitoringMode = MonitoringMode.Reporting;
-                monitoredItem.SamplingInterval = 0;
+                monitoredItem.SamplingInterval = 1000;
                 monitoredItem.QueueSize = 0;
                 monitoredItem.DiscardOldest = true;
 


### PR DESCRIPTION
Some OPC UA Servers (e.g. PLCs) have to poll data in order to report changes of values.
If a sampling rate of 0 is provided, the server is forced to poll as fast as possible.