### PR TITLE
Dockerfile for building a Docker container with a Windows Server 2016…

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,0 +1,14 @@
+FROM microsoft/dotnet:1.1-sdk-nanoserver
+
+COPY / /build
+
+WORKDIR /build
+RUN dotnet restore
+
+WORKDIR /build/src/GatewayApp.NetCore
+RUN dotnet publish -c Debug -f netcoreapp1.1 -r win10-x64 -o bin/Debug/netcoreapp1.1
+
+WORKDIR /build/src/GatewayApp.NetCore/bin/Debug/netcoreapp1.1
+RUN dir
+ENV PATH=/build/src/GatewayApp.NetCore/bin/Debug/netcoreapp1.1
+ENTRYPOINT ["./GatewayApp.NetCore"]


### PR DESCRIPTION
Adding a Dockerfile specific to building a Docker container with Windows Server 2016 NanoServer image with .NET Core 1.1. This is required if you are running the Docker daemon in Windows Server 2016, which only runs native Windows images. Typically Process Control Network (PCN) runs Windows machines or VMs, so this comes in handy.