### PR TITLE
Add configuration option to control OPC sampling and publishing intervals

### DIFF
--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -15,8 +15,14 @@ namespace Opc.Ua.Publisher
     using static Opc.Ua.Workarounds.TraceWorkaround;
     using static Program;
 
+    /// <summary>
+    /// Class to handle all IoTHub communication.
+    /// </summary>
     public class IotHubMessaging
     {
+        /// <summary>
+        /// Classes for the telemetry message sent to IoTHub.
+        /// </summary>
         private class OpcUaMessage
         {
             public string ApplicationUri { get; set; }
@@ -43,6 +49,9 @@ namespace Opc.Ua.Publisher
         private AutoResetEvent _sendQueueEvent;
         private DeviceClient _iotHubClient;
 
+        /// <summary>
+        /// Ctor for the class.
+        /// </summary>
         public IotHubMessaging()
         {
             _sendQueue = new ConcurrentQueue<string>();
@@ -52,6 +61,10 @@ namespace Opc.Ua.Publisher
             _currentSizeOfIotHubMessageBytes = 0;
         }
 
+        /// <summary>
+        /// Initializes the communication with secrets and details for (batched) send process.
+        /// </summary>
+        /// <returns></returns>
         public bool Init(string iotHubOwnerConnectionString, uint maxSizeOfIoTHubMessageBytes, int defaultSendIntervalSeconds)
         {
             _maxSizeOfIoTHubMessageBytes = maxSizeOfIoTHubMessageBytes;
@@ -143,6 +156,10 @@ namespace Opc.Ua.Publisher
             return true;
         }
 
+        /// <summary>
+        /// Method to write the IoTHub owner connection string into the cert store. 
+        /// </summary>
+        /// <param name="iotHubOwnerConnectionString"></param>
         public void ConnectionStringWrite(string iotHubOwnerConnectionString)
         {
             DeviceClient newClient = DeviceClient.CreateFromConnectionString(iotHubOwnerConnectionString, IotHubProtocol);
@@ -152,6 +169,9 @@ namespace Opc.Ua.Publisher
             _iotHubClient = newClient;
         }
 
+        /// <summary>
+        /// Shuts down the IoTHub communication.
+        /// </summary>
         public void Shutdown()
         {
             // send cancellation token and wait for last IoT Hub message to be sent.
@@ -180,7 +200,7 @@ namespace Opc.Ua.Publisher
         }
 
         //
-        // Enqueue a message.
+        // Enqueue a message for batch send.
         //
         public void Enqueue(string json)
         {
@@ -189,7 +209,7 @@ namespace Opc.Ua.Publisher
         }
 
         /// <summary>
-        /// Dequeue messages
+        /// Dequeue telemetry messages, compose them for batch send (if needed) and prepares them for sending to IoTHub.
         /// </summary>
         private async Task DeQueueMessagesAsync(CancellationToken ct)
         {
@@ -281,7 +301,7 @@ namespace Opc.Ua.Publisher
         }
 
         /// <summary>
-        /// Send dequeued messages to IoT Hub
+        /// Send messages to IoT Hub
         /// </summary>
         private async Task SendToIoTHubAsync()
         {
@@ -324,8 +344,6 @@ namespace Opc.Ua.Publisher
                 Trace(Utils.TraceMasks.OperationDetail, $"Retart timer to send data to IoTHub in {_defaultSendIntervalSeconds} second(s).");
                 _sendTimer.Change(TimeSpan.FromSeconds(_defaultSendIntervalSeconds), TimeSpan.FromSeconds(_defaultSendIntervalSeconds));
             }
-
-
         }
     }
 }

--- a/src/ModuleConfiguration.cs
+++ b/src/ModuleConfiguration.cs
@@ -53,11 +53,14 @@ namespace Opc.Ua.Publisher
             Trace($"Log file is: {Utils.GetAbsoluteFilePath(Configuration.TraceConfiguration.OutputFilePath, true, false, false, true)}");
             Trace($"opcstacktracemask set to: 0x{Program.OpcStackTraceMask:X} ({Program.OpcStackTraceMask})");
 
-            Configuration.SecurityConfiguration = new SecurityConfiguration();
-
-            // Trusted cert store configuration.
-            Configuration.SecurityConfiguration.TrustedPeerCertificates = new CertificateTrustList();
-            Configuration.SecurityConfiguration.TrustedPeerCertificates.StoreType = Program.OpcTrustedCertStoreType;
+            Configuration.SecurityConfiguration = new SecurityConfiguration()
+            {
+                // Trusted cert store configuration.
+                TrustedPeerCertificates = new CertificateTrustList()
+                {
+                    StoreType = Program.OpcTrustedCertStoreType
+                }
+            };
             if (string.IsNullOrEmpty(Program.OpcTrustedCertStorePath))
             {
                 // Set default.
@@ -76,16 +79,20 @@ namespace Opc.Ua.Publisher
             Trace($"Trusted Peer Certificate store path is: {Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
 
             // Trusted issuer cert store configuration.
-            Configuration.SecurityConfiguration.TrustedIssuerCertificates = new CertificateTrustList();
-            Configuration.SecurityConfiguration.TrustedIssuerCertificates.StoreType = Program.OpcIssuerCertStoreType;
-            Configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath = Program.OpcIssuerCertStorePath;
+            Configuration.SecurityConfiguration.TrustedIssuerCertificates = new CertificateTrustList()
+            {
+                StoreType = Program.OpcIssuerCertStoreType,
+                StorePath = Program.OpcIssuerCertStorePath
+            };
             Trace($"Trusted Issuer store type is: {Configuration.SecurityConfiguration.TrustedIssuerCertificates.StoreType}");
             Trace($"Trusted Issuer Certificate store path is: {Configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath}");
 
             // Rejected cert store configuration.
-            Configuration.SecurityConfiguration.RejectedCertificateStore = new CertificateTrustList();
-            Configuration.SecurityConfiguration.RejectedCertificateStore.StoreType = Program.OpcRejectedCertStoreType;
-            Configuration.SecurityConfiguration.RejectedCertificateStore.StorePath = Program.OpcRejectedCertStorePath;
+            Configuration.SecurityConfiguration.RejectedCertificateStore = new CertificateTrustList()
+            {
+                StoreType = Program.OpcRejectedCertStoreType,
+                StorePath = Program.OpcRejectedCertStorePath
+            };
             Trace($"Rejected certificate store type is: {Configuration.SecurityConfiguration.RejectedCertificateStore.StoreType}");
             Trace($"Rejected Certificate store path is: {Configuration.SecurityConfiguration.RejectedCertificateStore.StorePath}");
 

--- a/src/NodeToPublish.cs
+++ b/src/NodeToPublish.cs
@@ -5,13 +5,22 @@ using System.Collections.Generic;
 
 namespace Opc.Ua.Publisher
 {
-
+    /// <summary>
+    /// Class describing a list of nodes in the ExpandedNodeId format (using nsu as namespace syntax)
+    /// </summary>
     public class NodesOnEndpoint
     {
         public List<ExpandedNodeId> ExpandedNodeIds;
-        public int SamplingInterval;
+        public int? OpcSamplingInterval;
+        public int? OpcPublishingInterval;
     }
 
+    /// <summary>
+    /// Class describing the nodes which should be published. It supports three formats:
+    /// - NodeId syntax using the namespace index (ns) syntax
+    /// - ExpandedNodeId syntax, using the namespace URI (nsu) syntax
+    /// - List of ExpandedNodeId syntax, to allow putting nodes with similar publishing and/or sampling intervals in one object
+    /// </summary>
     public partial class NodeToPublish
     {
         public NodeToPublish()
@@ -25,14 +34,38 @@ namespace Opc.Ua.Publisher
         }
 
         [JsonProperty("EndpointUrl")]
-        public Uri EndPointUri { get; set; }
+        public Uri EndPointUri;
 
-        public ExpandedNodeId ExpandedNodeId { get; set; }
+        public bool ShouldGiveUp;
 
-        public NodeId NodeId { get; set; }
+        public ExpandedNodeId ExpandedNodeId;
 
-        public int SamplingInterval { get; set; }
+        public NodeId NodeId;
 
-        public NodesOnEndpoint Nodes { get; set; }
+        public int? OpcSamplingInterval;
+        public int? OpcPublishingInterval;
+        public NodesOnEndpoint Nodes;
+    }
+
+    /// <summary>
+    /// Comparer using the publishing interval as comparison element. Used to identify nodes to put on the same subscription.
+    /// </summary>
+    class NodePublishingIntervalComparer : IEqualityComparer<NodeToPublish>
+    {
+        public bool Equals(NodeToPublish n1, NodeToPublish n2)
+        {
+            if (n1.OpcPublishingInterval == null || n2.OpcPublishingInterval == null)
+            {
+                throw new Exception("Please make sure that the OpcPublishingInverval value is set for all nodes.");
+            }
+            if (n1.OpcPublishingInterval == n2.OpcPublishingInterval)
+                return true;
+            return false;
+        }
+
+        public int GetHashCode(NodeToPublish n)
+        {
+            return n.GetHashCode();
+        }
     }
 }

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -12,46 +12,59 @@ namespace Opc.Ua.Publisher
     using static Opc.Ua.Workarounds.TraceWorkaround;
     using static Program;
 
-    public class MonitoredItemInfo
+    /// <summary>
+    /// Class to manage the OPC monitored items, which are the nodes we need to publish.
+    /// </summary>
+    public class OpcMonitoredItem
     {
-        public enum MonitoredItemState
+        public enum OpcMonitoredItemState
         {
             Unmonitored = 0,
             Monitoreded,
             StopMonitoring,
         }
 
-        public ExpandedNodeId StartNodeId { get; set; }
-        public string DisplayName { get; set; }
-        public MonitoredItemState State { get; set; }
-        public uint AttributeId { get; set; }
-        public MonitoringMode MonitoringMode { get; set; }
-        public int SamplingInterval { get; set; }
-        public uint QueueSize { get; set; }
-        public bool DiscardOldest { get; set; }
-        public MonitoredItemNotificationEventHandler Notification { get; set; }
-        public Uri EndpointUri { get; set; }
+        public ExpandedNodeId StartNodeId;
+        public string DisplayName;
+        public OpcMonitoredItemState State;
+        public uint AttributeId;
+        public MonitoringMode MonitoringMode;
+        public int RequestedSamplingInterval;
+        public int SamplingInterval;
+        public uint QueueSize;
+        public bool DiscardOldest;
+        public MonitoredItemNotificationEventHandler Notification;
+        public Uri EndpointUri;
         public MonitoredItem MonitoredItem;
 
-        public MonitoredItemInfo(NodeId nodeId, Uri sessionEndpointUri)
+        /// <summary>
+        /// Ctor using NodeId (ns syntax for namespace).
+        /// </summary>
+        public OpcMonitoredItem(NodeId nodeId, Uri sessionEndpointUri)
         {
             StartNodeId = new ExpandedNodeId(nodeId);
             Initialize(sessionEndpointUri);
         }
 
-        public MonitoredItemInfo(ExpandedNodeId expandedNodeId, Uri sessionEndpointUri)
+        /// <summary>
+        /// Ctor using ExpandedNodeId (nsu syntax for namespace).
+        /// </summary>
+        public OpcMonitoredItem(ExpandedNodeId expandedNodeId, Uri sessionEndpointUri)
         {
             StartNodeId = expandedNodeId;
             Initialize(sessionEndpointUri);
         }
 
+        /// <summary>
+        /// Init class variables.
+        /// </summary>
         private void Initialize(Uri sessionEndpointUri)
         {
-            State = MonitoredItemState.Unmonitored;
+            State = OpcMonitoredItemState.Unmonitored;
             DisplayName = string.Empty;
             AttributeId = Attributes.Value;
             MonitoringMode = MonitoringMode.Reporting;
-            SamplingInterval = OpcSamplingRateMillisec;
+            RequestedSamplingInterval = OpcSamplingInterval;
             QueueSize = 0;
             DiscardOldest = true;
             Notification = new MonitoredItemNotificationEventHandler(MonitoredItem_Notification);
@@ -59,7 +72,7 @@ namespace Opc.Ua.Publisher
         }
 
         /// <summary>
-        /// The notification that the data for a monitored item has changed on an OPC UA server
+        /// The notification that the data for a monitored item has changed on an OPC UA server.
         /// </summary>
         public static void MonitoredItem_Notification(MonitoredItem monitoredItem, MonitoredItemNotificationEventArgs args)
         {
@@ -113,6 +126,28 @@ namespace Opc.Ua.Publisher
         }
     }
 
+    /// <summary>
+    /// Class to manage OPC subscriptions. We create a subscription for each different publishing interval
+    /// on an Endpoint.
+    /// </summary>
+    public class OpcSubscription
+    {
+        public List<OpcMonitoredItem> OpcMonitoredItems;
+        public int RequestedPublishingInterval;
+        public double PublishingInterval;
+        public Subscription Subscription;
+
+        public OpcSubscription(int? publishingInterval)
+        {
+            RequestedPublishingInterval = publishingInterval ?? OpcPublishingInterval;
+            PublishingInterval = RequestedPublishingInterval;
+            OpcMonitoredItems = new List<OpcMonitoredItem>();
+        }
+    }
+
+    /// <summary>
+    /// Class to manage OPC sessions.
+    /// </summary>
     public class OpcSession
     {
         public enum SessionState
@@ -121,37 +156,54 @@ namespace Opc.Ua.Publisher
             Connected,
         }
 
-        public Uri EndpointUri { get; set; }
-        public Session Session { get; set; }
-        public SessionState State { get; set; }
-        public List<MonitoredItemInfo> MonitoredItemsInfo;
+        public Uri EndpointUri;
+        public Session Session;
+        public SessionState State;
+        public List<OpcSubscription> OpcSubscriptions;
         public uint SessionTimeout { get; }
-        public uint UnsuccessfulConnectionCount { get; set; }
-        public uint MissedKeepAlives { get; set; }
+        public uint UnsuccessfulConnectionCount;
+        public uint MissedKeepAlives;
+        public int PublishingInterval;
         private SemaphoreSlim _opcSessionSemaphore;
         private NamespaceTable _namespaceTable;
+        private double _minSupportedSamplingInterval;
 
+        /// <summary>
+        /// Ctor for the session.
+        /// </summary>
+        /// <param name="endpointUri"></param>
+        /// <param name="sessionTimeout"></param>
         public OpcSession(Uri endpointUri, uint sessionTimeout)
         {
             State = SessionState.Disconnected;
             EndpointUri = endpointUri;
             SessionTimeout = sessionTimeout * 1000;
-            MonitoredItemsInfo = new List<MonitoredItemInfo>();
+            OpcSubscriptions = new List<OpcSubscription>();
             UnsuccessfulConnectionCount = 0;
             MissedKeepAlives = 0;
+            PublishingInterval = OpcPublishingInterval;
             _opcSessionSemaphore = new SemaphoreSlim(1);
             _namespaceTable = new NamespaceTable();
         }
 
+        /// <summary>
+        /// This task is executed regularily and ensures:
+        /// - disconnected sessions are reconnected.
+        /// - monitored nodes are no longer monitored if requested to do so.
+        /// - monitoring for a node starts if it is required.
+        /// - unused subscriptions (without any nodes to monitor) are removed.
+        /// - sessions with out subscriptions are removed.
+        /// </summary>
+        /// <returns></returns>
         public async Task ConnectAndMonitor()
         {
             _opcSessionSemaphore.Wait();
-            Trace($"Connect and monitor session and nodes on endpoint '{EndpointUri.AbsoluteUri}'.");
             try
             {
-                // if the session is disconnected, create it.
+                // if the session is disconnected, create one.
                 if (State == SessionState.Disconnected)
                 {
+                    Trace($"Connect and monitor session and nodes on endpoint '{EndpointUri.AbsoluteUri}'.");
                     EndpointDescription selectedEndpoint = CoreClientUtils.SelectEndpoint(EndpointUri.AbsoluteUri, true);
                     ConfiguredEndpoint configuredEndpoint = new ConfiguredEndpoint(selectedEndpoint.Server, EndpointConfiguration.Create(OpcConfiguration));
                     configuredEndpoint.Update(selectedEndpoint);
@@ -173,7 +225,7 @@ namespace Opc.Ua.Publisher
                         if (Session != null)
                         {
                             Trace($"Session successfully created with Id {Session.SessionId}.");
-                            if (!selectedEndpoint.EndpointUrl.Equals(configuredEndpoint.EndpointUrl))
+                            if (!selectedEndpoint.EndpointUrl.Equals(configuredEndpoint.EndpointUrl.AbsoluteUri))
                             {
                                 Trace($"the Server has updated the EndpointUrl to '{selectedEndpoint.EndpointUrl}'");
                             }
@@ -182,11 +234,10 @@ namespace Opc.Ua.Publisher
                             UnsuccessfulConnectionCount = 0;
                             State = SessionState.Connected;
                             Session.KeepAliveInterval = OpcKeepAliveIntervalInSec * 1000;
-                            Session.KeepAlive += new KeepAliveEventHandler((sender, e) => StandardClient_KeepAlive(sender, e, Session));
+                            Session.KeepAlive += StandardClient_KeepAlive;
 
                             // fetch the namespace array and cache it. it will not change as long the session exists.
-                            NodeId namespaceArrayNodeId = new NodeId(Variables.Server_NamespaceArray, 0);
-                            DataValue namespaceArrayNodeValue = Session.ReadValue(namespaceArrayNodeId);
+                            DataValue namespaceArrayNodeValue = Session.ReadValue(VariableIds.Server_NamespaceArray);
                             _namespaceTable.Update(namespaceArrayNodeValue.GetValue<string[]>(null));
 
                             // show the available namespaces
@@ -196,6 +247,11 @@ namespace Opc.Ua.Publisher
                             {
                                 Trace($"Namespace index {i++}: {ns}");
                             }
+
+                            // fetch the minimum supported item sampling interval from the server.
+                            DataValue minSupportedSamplingInterval = Session.ReadValue(VariableIds.Server_ServerCapabilities_MinSupportedSampleRate);
+                            _minSupportedSamplingInterval = minSupportedSamplingInterval.GetValue(0);
+                            Trace($"The server on endpoint '{selectedEndpoint.EndpointUrl}' supports a minimal sampling interval of {_minSupportedSamplingInterval} ms.");
                         }
                     }
                     catch (Exception e)
@@ -208,153 +264,247 @@ namespace Opc.Ua.Publisher
                 }
 
                 // stop monitoring of nodes if requested and remove them from the monitored items list.
-                var itemsToRemove = MonitoredItemsInfo.Where(i => i.State == MonitoredItemInfo.MonitoredItemState.StopMonitoring);
-                if (itemsToRemove.GetEnumerator().MoveNext())
+                foreach (var opcSubscription in OpcSubscriptions)
                 {
-                    itemsToRemove.GetEnumerator().Reset();
-                    Trace($"Remove nodes on endpoint '{EndpointUri.AbsoluteUri}'");
-                    Session.DefaultSubscription.RemoveItems(itemsToRemove.Select(i => i.MonitoredItem));
+                    var itemsToRemove = opcSubscription.OpcMonitoredItems.Where(i => i.State == OpcMonitoredItem.OpcMonitoredItemState.StopMonitoring);
+                    if (itemsToRemove.Any())
+                    {
+                        Trace($"Remove nodes in subscription with id {opcSubscription.Subscription.Id} on endpoint '{EndpointUri.AbsoluteUri}'");
+                        opcSubscription.Subscription.RemoveItems(itemsToRemove.Select( i => i.MonitoredItem ));
+                    }
                 }
 
-                // ensure all nodes on this session are monitored.
-                Trace($"Start monitoring nodes on endpoint '{EndpointUri.AbsoluteUri}'");
-                var unmonitoredItems = MonitoredItemsInfo.Where(i => i.State == MonitoredItemInfo.MonitoredItemState.Unmonitored);
-                foreach (var item in unmonitoredItems)
+                // ensure all nodes in all subscriptions of this session are monitored.
+                foreach (var opcSubscription in OpcSubscriptions)
                 {
-                    // if the session is disconnected, we stop trying and wait for the next cycle
-                    if (State == SessionState.Disconnected)
+                    // create the subscription, if it is not yet there.
+                    if (opcSubscription.Subscription == null)
                     {
-                        break;
+                        int revisedPublishingInterval;
+                        opcSubscription.Subscription = CreateSubscription(opcSubscription.RequestedPublishingInterval, out revisedPublishingInterval);
+                        opcSubscription.PublishingInterval = revisedPublishingInterval;
+                        Trace($"Create subscription on endpoint '{EndpointUri.AbsoluteUri}' requested OPC publishing interval is {opcSubscription.RequestedPublishingInterval} ms. (revised: {revisedPublishingInterval} ms)");
                     }
 
-                    NodeId currentNodeId;
-                    try
+                    // process all unmonitored items.
+                    var unmonitoredItems = opcSubscription.OpcMonitoredItems.Where(i => i.State == OpcMonitoredItem.OpcMonitoredItemState.Unmonitored);
+
+                    foreach (var item in unmonitoredItems)
                     {
-                        Subscription subscription = Session.DefaultSubscription;
-                        if (Session.AddSubscription(subscription))
+                        // if the session is disconnected, we stop trying and wait for the next cycle
+                        if (State == SessionState.Disconnected)
                         {
-                            Trace("Create default subscription.");
-                            subscription.Create();
+                            break;
                         }
 
-                        // lookup namespace index if ExpandedNodeId format has been used and build NodeId identifier.
-                        if (!string.IsNullOrEmpty(item.StartNodeId.NamespaceUri))
+                        Trace($"Start monitoring nodes on endpoint '{EndpointUri.AbsoluteUri}'.");
+                        NodeId currentNodeId;
+                        bool subscriptionUpdateRequired = false;
+                        try
                         {
-                            currentNodeId = NodeId.Create(item.StartNodeId.Identifier, item.StartNodeId.NamespaceUri, _namespaceTable);
-                        }
-                        else
-                        {
-                            currentNodeId = new NodeId((NodeId)item.StartNodeId);
-                        }
+                            // lookup namespace index if ExpandedNodeId format has been used and build NodeId identifier.
+                            if (!string.IsNullOrEmpty(item.StartNodeId.NamespaceUri))
+                            {
+                                currentNodeId = NodeId.Create(item.StartNodeId.Identifier, item.StartNodeId.NamespaceUri, _namespaceTable);
+                            }
+                            else
+                            {
+                                currentNodeId = new NodeId((NodeId)item.StartNodeId);
+                            }
 
-                        // get the DisplayName for the node, otherwise use the nodeId
-                        Node node = Session.ReadNode(currentNodeId);
-                        item.DisplayName = node.DisplayName.Text ?? currentNodeId.ToString();
+                            // get the DisplayName for the node, otherwise use the nodeId
+                            Node node = Session.ReadNode(currentNodeId);
+                            item.DisplayName = node.DisplayName.Text ?? currentNodeId.ToString();
 
-                        // add the new monitored item.
-                        MonitoredItem monitoredItem = new MonitoredItem(subscription.DefaultItem)
-                        {
-                            StartNodeId = currentNodeId,
-                            AttributeId = item.AttributeId,
-                            DisplayName = node.DisplayName.Text,
-                            MonitoringMode = item.MonitoringMode,
-                            SamplingInterval = item.SamplingInterval,
-                            QueueSize = item.QueueSize,
-                            DiscardOldest = item.DiscardOldest
-                        };
-                        monitoredItem.Notification += item.Notification;
-                        subscription.AddItem(monitoredItem);
-                        subscription.ApplyChanges();
-                        item.MonitoredItem = monitoredItem;
-                        item.State = MonitoredItemInfo.MonitoredItemState.Monitoreded;
-                        item.EndpointUri = EndpointUri;
-                        Trace($"Created monitored item for node '{currentNodeId}' on endpoint '{EndpointUri.AbsoluteUri}'");
-                    }
-                    catch (Exception e) when (e.GetType() == typeof(ServiceResultException))
-                    {
-                        ServiceResultException sre = (ServiceResultException)e;
-                        switch ((uint)sre.Result.StatusCode)
-                        {
-                            case StatusCodes.BadSessionIdInvalid:
-                                {
-                                    Trace($"Session with Id {Session.SessionId} is no longer available on endpoint '{EndpointUri}'. Cleaning up.");
-                                    // clean up the session
-                                    _opcSessionSemaphore.Release();
-                                    Disconnect();
-                                    break;
-                                }
-                            case StatusCodes.BadNodeIdInvalid:
-                            case StatusCodes.BadNodeIdUnknown:
-                                {
-                                    Trace($"Failed to monitor node '{item.StartNodeId.Identifier}' on endpoint '{EndpointUri}'.");
-                                    Trace($"OPC UA ServiceResultException is '{sre.Result}'. Please check your publisher configuration for this node.");
-                                    break;
-                                }
-                            default:
-                                {
-                                    Trace($"Unhandled OPC UA ServiceResultException '{sre.Result}' when monitoring node '{item.StartNodeId.Identifier}' on endpoint '{EndpointUri}'. Continue.");
-                                    break;
-                                }
+                            // add the new monitored item.
+                            MonitoredItem monitoredItem = new MonitoredItem()
+                            {
+                                StartNodeId = currentNodeId,
+                                AttributeId = item.AttributeId,
+                                DisplayName = node.DisplayName.Text,
+                                MonitoringMode = item.MonitoringMode,
+                                SamplingInterval = item.RequestedSamplingInterval,
+                                QueueSize = item.QueueSize,
+                                DiscardOldest = item.DiscardOldest
+                            };
+                            monitoredItem.Notification += item.Notification;
+                            opcSubscription.Subscription.AddItem(monitoredItem);
+                            opcSubscription.Subscription.SetPublishingMode(true);
+                            opcSubscription.Subscription.ApplyChanges();
+                            item.MonitoredItem = monitoredItem;
+                            item.State = OpcMonitoredItem.OpcMonitoredItemState.Monitoreded;
+                            item.EndpointUri = EndpointUri;
+                            Trace($"Created monitored item for node '{currentNodeId}' in subscription with id {opcSubscription.Subscription.Id} on endpoint '{EndpointUri.AbsoluteUri}'");
+                            if (item.RequestedSamplingInterval != monitoredItem.SamplingInterval)
+                            {
+                                Trace($"Sampling interval: requested: {item.RequestedSamplingInterval}; revised: {monitoredItem.SamplingInterval}");
+                                item.SamplingInterval = monitoredItem.SamplingInterval;
+                            }
+                            if (item.SamplingInterval > opcSubscription.PublishingInterval)
+                            {
+                                Trace($"Publishing interval update required to {item.SamplingInterval} ms.");
+                                // todo
+                                subscriptionUpdateRequired = true;
+                            }
+
                         }
-                    }
-                    catch (Exception e)
-                    {
+                        catch (Exception e) when (e.GetType() == typeof(ServiceResultException))
+                        {
+                            ServiceResultException sre = (ServiceResultException)e;
+                            switch ((uint)sre.Result.StatusCode)
+                            {
+                                case StatusCodes.BadSessionIdInvalid:
+                                    {
+                                        Trace($"Session with Id {Session.SessionId} is no longer available on endpoint '{EndpointUri}'. Cleaning up.");
+                                        // clean up the session
+                                        _opcSessionSemaphore.Release();
+                                        await Disconnect();
+                                        break;
+                                    }
+                                case StatusCodes.BadNodeIdInvalid:
+                                case StatusCodes.BadNodeIdUnknown:
+                                    {
+                                        Trace($"Failed to monitor node '{item.StartNodeId.Identifier}' on endpoint '{EndpointUri}'.");
+                                        Trace($"OPC UA ServiceResultException is '{sre.Result}'. Please check your publisher configuration for this node.");
+                                        break;
+                                    }
+                                default:
+                                    {
+                                        Trace($"Unhandled OPC UA ServiceResultException '{sre.Result}' when monitoring node '{item.StartNodeId.Identifier}' on endpoint '{EndpointUri}'. Continue.");
+                                        break;
+                                    }
+                            }
+                        }
+                        catch (Exception e)
+                        {
                             Trace(e, $"Failed to monitor node '{item.StartNodeId.Identifier}' on endpoint '{EndpointUri}'");
+                        }
+                        // check if a subscription update is required.
+                        if (subscriptionUpdateRequired)
+                        {
+                            Trace($"Subscription with id {opcSubscription.Subscription.Id} on endpoint '{EndpointUri}' needs to be updated.");
+                            // todo
+                        }
+                    }
+                }
+
+                // remove unused subscriptions.
+                foreach (var opcSubscription in OpcSubscriptions)
+                {
+                    if (opcSubscription.OpcMonitoredItems.Count == 0)
+                    {
+                        Trace($"Subscription with id {opcSubscription.Subscription.Id} on endpoint '{EndpointUri}' is not used and will be deleted.");
+                        Session.RemoveSubscription(opcSubscription.Subscription);
+                        opcSubscription.Subscription = null;
                     }
                 }
 
                 // shutdown unused sessions.
-                var unusedSessions = OpcSessions.Where(s => s.MonitoredItemsInfo.Count == 0);
+                var unusedSessions = OpcSessions.Where(s => s.OpcSubscriptions.Count == 0);
                 foreach (var unusedSession in unusedSessions)
                 {
                     await unusedSession.Shutdown();
                     OpcSessions.Remove(unusedSession);
                 }
             }
+            catch (Exception e)
+            {
+                Trace(e, "Error during ConnectAndMonitor.");
+            }
             finally
             {
                 _opcSessionSemaphore.Release();
             }
         }
 
+        /// <summary>
+        /// Disconnects a session and removes all subscriptions on it and marks all nodes on those subscriptions
+        /// as unmonitored.
+        /// </summary>
+        /// <returns></returns>
         public async Task Disconnect()
         {
             _opcSessionSemaphore.Wait();
             try
             {
-                Session.RemoveSubscriptions(Session.Subscriptions);
-                Session.Close();
+                foreach (var opcSubscription in OpcSubscriptions)
+                {
+                    try
+                    {
+                        Session.RemoveSubscription(opcSubscription.Subscription);
+                    }
+                    catch
+                    {
+                        // the session might be already invalidated. ignore.
+                    }
+                    try
+                    {
+                        opcSubscription.Subscription.Delete(true);
+                    }
+                    catch
+                    {
+                        // the subscription might be already invalidated. ignore.
+                    }
+                    opcSubscription.Subscription = null;
+
+                    // mark all monitored items as unmonitored
+                    foreach (var opcMonitoredItem in opcSubscription.OpcMonitoredItems)
+                    {
+                        opcMonitoredItem.State = OpcMonitoredItem.OpcMonitoredItemState.Unmonitored;
+                    }
+                }
+                try
+                {
+                    Session.Close();
+                }
+                    catch
+                    {
+                        // the session might be already invalidated. ignore.
+                    }
+                Session = null;
             }
             catch (Exception e)
             {
-                // in case of a bad session disconnect this is expected
+                // we do not care much. ignore.
             }
             State = SessionState.Disconnected;
-
-            // mark all monitored items as unmonitored
-            foreach (var monitoredItemInfo in MonitoredItemsInfo)
-            {
-                monitoredItemInfo.State = MonitoredItemInfo.MonitoredItemState.Unmonitored;
-            }
             MissedKeepAlives = 0;
+
             _opcSessionSemaphore.Release();
         }
 
-        public void AddNodeForMonitoring(NodeId nodeId)
+        /// <summary>
+        /// Adds a node to be monitored. If there is no session to the endpoint, one is created.
+        /// If there is no spubscription with the requested publishing interval, one is created.
+        /// </summary>
+        /// <param name="publishingInterval"></param>
+        /// <param name="nodeId"></param>
+        public void AddNodeForMonitoring(int publishingInterval, NodeId nodeId)
         {
             _opcSessionSemaphore.Wait();
             try
             {
-                MonitoredItemInfo monitoredItemInfo = MonitoredItemsInfo.First(m => m.StartNodeId == nodeId);
-
-                // if it is already there, we just ignore it, otherwise we add a new item to monitor.
-                if (monitoredItemInfo == null)
+                // find a subscription we could the node monitor on
+                OpcSubscription opcSubscription = OpcSubscriptions.First(s => s.RequestedPublishingInterval == publishingInterval);
+                // if there was none found, create one
+                if (opcSubscription == null)
                 {
-                    // add a new item to monitor
-                    monitoredItemInfo = new MonitoredItemInfo(nodeId, EndpointUri);
-                    MonitoredItemsInfo.Add(monitoredItemInfo);
+                    int revisedPublishingInterval;
+                    opcSubscription = new OpcSubscription(publishingInterval)
+                    {
+                        Subscription = CreateSubscription(publishingInterval, out revisedPublishingInterval),
+                        PublishingInterval = revisedPublishingInterval
+                    };
                 }
 
+                // if it is already there, we just ignore it, otherwise we add a new item to monitor.
+                OpcMonitoredItem opcMonitoredItem = opcSubscription.OpcMonitoredItems.First(m => m.StartNodeId == nodeId);
+                if (opcMonitoredItem == null)
+                {
+                    // add a new item to monitor
+                    opcMonitoredItem = new OpcMonitoredItem(nodeId, EndpointUri);
+                    opcSubscription.OpcMonitoredItems.Add(opcMonitoredItem);
+                }
             }
             finally
             {
@@ -362,20 +512,28 @@ namespace Opc.Ua.Publisher
             }
         }
 
+        /// <summary>
+        /// Tags a monitored node to stop monitoring.
+        /// </summary>
+        /// <param name="nodeId"></param>
         public void TagNodeForMonitoringStop(NodeId nodeId)
         {
             _opcSessionSemaphore.Wait();
             try
             {
-                MonitoredItemInfo monitoredItemInfo = MonitoredItemsInfo.First(m => m.StartNodeId == nodeId);
+                // find all subscriptions the node is monitored on.
+                var opcSubscriptions = OpcSubscriptions.Where( s => s.OpcMonitoredItems.Any(m => m.StartNodeId == nodeId));
 
-                // if it is not there, we just ignore it, otherwise we tag it for removal.
-                if (monitoredItemInfo == null)
+                // tag all monitored items with nodeId to stop monitoring.
+                foreach (var opcSubscription in opcSubscriptions)
                 {
-                    // tag it for removal.
-                    monitoredItemInfo.State = MonitoredItemInfo.MonitoredItemState.StopMonitoring;
+                    var opcMonitoredItems = opcSubscription.OpcMonitoredItems.Where(i => i.StartNodeId == nodeId);
+                    foreach (var opcMonitoredItem in opcMonitoredItems)
+                    {
+                        // tag it for removal.
+                        opcMonitoredItem.State = OpcMonitoredItem.OpcMonitoredItemState.StopMonitoring;
+                    }
                 }
-
             }
             finally
             {
@@ -383,6 +541,10 @@ namespace Opc.Ua.Publisher
             }
         }
 
+        /// <summary>
+        /// Shutsdown all connected sessions.
+        /// </summary>
+        /// <returns></returns>
         public async Task Shutdown()
         {
             _opcSessionSemaphore.Wait();
@@ -393,8 +555,13 @@ namespace Opc.Ua.Publisher
                 {
                     try
                     {
-                        Trace($"Removing {Session.DefaultSubscription.MonitoredItemCount} monitored items from default subscription from session to endpoint URI '{EndpointUri.AbsoluteUri}'.");
-                        Session.DefaultSubscription.RemoveItems(Session.DefaultSubscription.MonitoredItems);
+                        foreach (var opcSubscription in OpcSubscriptions)
+                        {
+                            Trace($"Removing {opcSubscription.Subscription.MonitoredItemCount} monitored items from subscription with id {opcSubscription.Subscription.Id}.");
+                            opcSubscription.Subscription.RemoveItems(opcSubscription.Subscription.MonitoredItems);
+                        }
+                        Trace($"Removing {Session.SubscriptionCount} subscriptions from session.");
+                        Session.RemoveSubscriptions(Session.Subscriptions);
                         Trace($"Closing session to endpoint URI '{EndpointUri.AbsoluteUri}' closed successfully.");
                         Session.Close();
                         State = SessionState.Disconnected;
@@ -419,25 +586,51 @@ namespace Opc.Ua.Publisher
         }
 
         /// <summary>
+        /// Create a subscription in the session.
+        /// </summary>
+        /// <param name="requestedPublishingInterval"></param>
+        /// <param name="revisedPublishingInterval"></param>
+        /// <returns></returns>
+        private Subscription CreateSubscription(int requestedPublishingInterval, out int revisedPublishingInterval)
+        {
+            Subscription subscription = new Subscription()
+            {
+                PublishingInterval = requestedPublishingInterval,
+            };
+            // need to happen before the create to set the Session property.
+            Session.AddSubscription(subscription);
+            subscription.Create();
+            Trace($"Created subscription with id {subscription.Id} on endpoint '{EndpointUri.AbsoluteUri}'");
+            if (requestedPublishingInterval != subscription.PublishingInterval)
+            {
+                Trace($"Publishing interval: requested: {requestedPublishingInterval}; revised: {subscription.PublishingInterval}");
+            }
+            revisedPublishingInterval = subscription.PublishingInterval;
+            return subscription;
+        }
+
+        /// <summary>
         /// Handler for the standard "keep alive" event sent by all OPC UA servers
         /// </summary>
-        private static void StandardClient_KeepAlive(Session sender, KeepAliveEventArgs e, Session session)
+        private static void StandardClient_KeepAlive(Session session, KeepAliveEventArgs e)
         {
             if (e != null && session != null)
             {
-                var opcSession = Program.OpcSessions.Where(s => s.Session.ConfiguredEndpoint.EndpointUrl.Equals(sender.ConfiguredEndpoint.EndpointUrl)).First();
+                var opcSession = Program.OpcSessions.Where(s => s.Session.ConfiguredEndpoint.EndpointUrl.Equals(session.ConfiguredEndpoint.EndpointUrl)).First();
                 if (!ServiceResult.IsGood(e.Status))
                 {
-                    Trace($"Session endpoint: {sender.ConfiguredEndpoint.EndpointUrl} has Status: {e.Status}");
+                    Trace($"Session endpoint: {session.ConfiguredEndpoint.EndpointUrl} has Status: {e.Status}");
                     Trace($"Outstanding requests: {session.OutstandingRequestCount}, Defunct requests: {session.DefunctRequestCount}");
-                    if (opcSession != null)
+                    Trace($"Good publish requests: {session.GoodPublishRequestCount}, KeepAlive interval: {session.KeepAliveInterval}");
+                    Trace($"SessionId: {session.SessionId}");
+                    if (opcSession != null && opcSession.State == SessionState.Connected)
                     {
                         opcSession.MissedKeepAlives++;
-                        Trace($"Now missed {opcSession.MissedKeepAlives} keep alive.");
+                        Trace($"Missed KeepAlives: {opcSession.MissedKeepAlives}");
                         if (opcSession.MissedKeepAlives >= OpcKeepAliveDisconnectThreshold)
                         {
-                            Trace($"Hit configured missed keep alive threshold of {Program.OpcKeepAliveDisconnectThreshold}. Disconnecting the session to endpoint {sender.ConfiguredEndpoint.EndpointUrl}.");
-                            session.KeepAlive -= new KeepAliveEventHandler((a, b) => StandardClient_KeepAlive(sender, e, session));
+                            Trace($"Hit configured missed keep alive threshold of {Program.OpcKeepAliveDisconnectThreshold}. Disconnecting the session to endpoint {session.ConfiguredEndpoint.EndpointUrl}.");
+                            session.KeepAlive -= StandardClient_KeepAlive;
                             opcSession.Disconnect();
                         }
                     }
@@ -447,7 +640,7 @@ namespace Opc.Ua.Publisher
                     if (opcSession.MissedKeepAlives != 0)
                     {
                         // Reset missed keep alive count
-                        Trace($"Session endpoint: {sender.ConfiguredEndpoint.EndpointUrl} got a keep alive after {opcSession.MissedKeepAlives} {(opcSession.MissedKeepAlives == 1 ? "was" : "were")} missed.");
+                        Trace($"Session endpoint: {session.ConfiguredEndpoint.EndpointUrl} got a keep alive after {opcSession.MissedKeepAlives} {(opcSession.MissedKeepAlives == 1 ? "was" : "were")} missed.");
                         opcSession.MissedKeepAlives = 0;
                     }
                 }

--- a/src/PublisherState.cs
+++ b/src/PublisherState.cs
@@ -18,7 +18,7 @@ namespace Publisher
     public partial class PublisherState
     {
         /// <summary>
-        /// Called after the class is created
+        /// Called after the class is created.
         /// </summary>
         protected override void OnAfterCreate(ISystemContext context, NodeState node)
         {
@@ -31,7 +31,7 @@ namespace Publisher
         }
 
         /// <summary>
-        /// Method exposed as a node in the server to publish a node to IoT Hub that it is connected to
+        /// Method to start monitoring a node and publish the data to IoTHub.
         /// </summary>
         private ServiceResult PublishNodeMethod(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
         {
@@ -60,13 +60,13 @@ namespace Publisher
                 return ServiceResult.Create(StatusCodes.BadArgumentsMissing, "Please provide a valid OPC UA endpoint URL as second argument!");
             }
 
-            // Create session and add item to monitor, what ever is needed.
+            // find/create a session to the endpoint URL and start monitoring the node.
             try
             {
                 // find the session we need to monitor the node
                 OpcSession opcSession = OpcSessions.First(s => s.EndpointUri == nodeToPublish.EndPointUri);
 
-                // Add a new session.
+                // add a new session.
                 if (opcSession == null)
                 {
                     // create new session info.
@@ -79,8 +79,8 @@ namespace Publisher
                     Trace($"DoPublish: Session found for endpoint '{nodeToPublish.EndPointUri.AbsolutePath}'");
                 }
 
-                // add the node info to the sessions monitored items list.
-                opcSession.AddNodeForMonitoring(nodeToPublish.NodeId);
+                // add the node info to the subscription with the default publishing interval
+                opcSession.AddNodeForMonitoring(OpcPublishingInterval, nodeToPublish.NodeId);
                 Trace("DoPublish: Requested to monitor item.");
 
                 // start monitoring the node
@@ -105,7 +105,7 @@ namespace Publisher
         }
 
         /// <summary>
-        /// Method exposed as a node in the server to stop monitoring it and no longer publish telemetry of it.
+        /// Method to remove the node from the subscription and stop publishing telemetry to IoTHub.
         /// </summary>
         private ServiceResult UnPublishNodeMethod(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
         {
@@ -134,7 +134,7 @@ namespace Publisher
                 return ServiceResult.Create(StatusCodes.BadArgumentsMissing, "Please provide a valid OPC UA endpoint URL as second argument!");
             }
 
-            // Find the session and stop monitoring the node.
+            // find the session and stop monitoring the node.
             try
             {
                 // find the session we need to monitor the node
@@ -175,7 +175,7 @@ namespace Publisher
         }
 
         /// <summary>
-        /// Method exposed as a node in the server to get a list of published nodes
+        /// Method to get the list of published nodes.
         /// </summary>
         private ServiceResult GetListOfPublishedNodesMethod(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
         {
@@ -186,7 +186,7 @@ namespace Publisher
         }
 
         /// <summary>
-        /// Data node in the server which registers ourselves with IoT Hub when this node is written to
+        /// Data node in the server which registers ourselves with IoT Hub when this node is written.
         /// </summary>
         public ServiceResult ConnectionStringWrite(ISystemContext context, NodeState node, NumericRange indexRange, QualifiedName dataEncoding, ref object value, ref StatusCode statusCode, ref DateTime timestamp)
         {

--- a/src/SecureIoTHubToken.cs
+++ b/src/SecureIoTHubToken.cs
@@ -21,6 +21,10 @@ namespace IoTHubCredentialTools
 {
     public class SecureIoTHubToken
     {
+        /// <summary>
+        /// Validates the cert and extracts the token from the cert.
+        /// </summary>
+        /// <returns></returns>
         private static string CheckForToken(X509Certificate2 cert, string name)
         {
             if ((cert.SubjectName.Decode(X500DistinguishedNameFlags.None | X500DistinguishedNameFlags.DoNotUseQuotes).Equals("CN=" + name, StringComparison.OrdinalIgnoreCase)) &&
@@ -47,6 +51,10 @@ namespace IoTHubCredentialTools
             return null;
         }
 
+        /// <summary>
+        /// Returns the token from the cert in the given cert store.
+        /// </summary>
+        /// <returns></returns>
         public static string Read(string name, string storeType, string storePath)
         {
             string token = null;
@@ -98,6 +106,9 @@ namespace IoTHubCredentialTools
             return null;
         }
 
+        /// <summary>
+        /// Creates a cert with the connectionstring (token) and stores it in the given cert store.
+        /// </summary>
         public static void Write(string name, string connectionString, string storeType, string storePath)
         {
             if (string.IsNullOrEmpty(connectionString))
@@ -227,6 +238,10 @@ namespace IoTHubCredentialTools
             }
         }
 
+        /// <summary>
+        /// Creates a X509 cert from a PKCS512 raw data stream.
+        /// </summary>
+        /// <returns></returns>
         private static X509Certificate2 CreateCertificateFromPKCS12(byte[] rawData, string password)
         {
             Exception ex = null;

--- a/src/TraceWorkaround.cs
+++ b/src/TraceWorkaround.cs
@@ -4,17 +4,35 @@ using static System.Console;
 
 namespace Opc.Ua.Workarounds
 {
-    using static Opc.Ua.Publisher.Program;
-
+    /// <summary>
+    /// Class to enable output to the console.
+    /// </summary>
     public static class TraceWorkaround
     {
+        private static int _opcStackTraceMask;
+        private static bool _verboseConsole;
+
+        public static void Init(int opcStackTraceMask, bool verboseConsole)
+        {
+            _opcStackTraceMask = opcStackTraceMask;
+            _verboseConsole = verboseConsole;
+        }
         /// <summary>
         /// Trace message helper
         /// </summary>
+        public static void Trace(string message)
+        {
+            Utils.Trace(Utils.TraceMasks.Error, message);
+            if (_verboseConsole)
+            {
+                WriteLine(DateTime.Now.ToString() + ": " + message);
+            }
+        }
+
         public static void Trace(string message, params object[] args)
         {
             Utils.Trace(Utils.TraceMasks.Error, message, args);
-            if (VerboseConsole)
+            if (_verboseConsole)
             {
                 WriteLine(DateTime.Now.ToString() + ": " + message, args);
             }
@@ -23,7 +41,7 @@ namespace Opc.Ua.Workarounds
         public static void Trace(int traceMask, string format, params object[] args)
         {
             Utils.Trace(traceMask, format, args);
-            if (VerboseConsole && (OpcStackTraceMask & traceMask) != 0)
+            if (_verboseConsole && (_opcStackTraceMask & traceMask) != 0)
             {
                 WriteLine(DateTime.Now.ToString() + ": " + format, args);
             }

--- a/src/publishednodes.json
+++ b/src/publishednodes.json
@@ -1,22 +1,41 @@
 ﻿[
     {
+        // Publisher will request the server at EndpointUrl to sample the node with the OPC sampling interval specified on command line (or the default value: OPC publishing interval)
+        // and the subscription will publish the node value with the OPC publishing interval specified on command line (or the default value: server revised interval).
+        // Publisher will use the default subscription to the OPC UA server to monitor the node.
+        // please consult the OPC UA specification for details on how OPC monitored node sampling interval and OPC subscription publishing interval settings are handled by the OPC UA stack.
+        // the publishing interval of the data to Azure IoTHub is controlled by the command line settings (or the default: publish data to IoTHub at least each 1 second).
+
         // example for an EnpointUrl is: opc.tcp://win10iot:51210/UA/SampleServer
         "EndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
         "ExpandedNodeId": {
             // the identifier specifies the NamespaceUri and the node identifier in XML notation as specified in Part 6 of the OPC UA specification in the XML Mapping section.
             "Identifier": "nsu=http://opcfoundation.org/UA/;i=2258"
         }
-        // since there is no SamplingInterval specified, the command line parameter or default SamplingInterval is used for the node.
     },
+
+
     {
+        // Publisher will request the server at EndpointUrl to sample the node with the OPC sampling interval specified on command line (or the default value: OPC publishing interval).
+        // Publisher will create a separate subscription to the OPC UA server to monitor the nodes and the OPC publishing interval for this subscription is set to 4000 ms.
+        // if the OPC sampling interval is set to an higher value, Publisher will adjust the OPC publishing interval of the subscription to this value.
+        // please consult the OPC UA specification for details on how OPC monitored node sampling interval and OPC subscription publishing interval settings are handled by the OPC UA stack.
+        // the publishing interval of the data to Azure IoTHub is controlled by the command line settings (or the default: publish data to IoTHub at least each 1 second).
         "EndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
         "ExpandedNodeId": {
             "Identifier": "nsu=http://opcfoundation.org/UA/;i=2258"
         },
-        // the specifice SamplingInterval is used for the configured node.
-        "SamplingInterval": 4000
+        "OpcPublishingInterval": 4000
     },
+
+
     {
+        // Publisher will request the server at EndpointUrl to sample the node with the OPC sampling interval of 1000 ms
+        // and the subscription will publish the node value with the OPC publishing interval specified on command line (or the default value: server revised interval).
+        // if the OPC publishing interval is set to a lower value, Publisher will adjust the OPC publishing interval of the subscription to the OPC sampling interval value.
+        // Publisher will use the default subscription to the OPC UA server to monitor the node.
+        // please consult the OPC UA specification for details on how OPC monitored node sampling interval and OPC subscription publishing interval settings are handled by the OPC UA stack.
+        // the publishing interval of the data to Azure IoTHub is controlled by the command line settings (or the default: publish data to IoTHub at least each 1 second).
         "EndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
         "Nodes": {
             "ExpandedNodeIds": [
@@ -24,13 +43,15 @@
                 { "Identifier": "nsu=http://opcfoundation.org/UA/;i=2258" },
                 { "Identifier": "nsu=http://opcfoundation.org/UA/;i=2258" }
             ],
-            // the SamplingInterval is used for all three configured nodes.
-            "SamplingInterval": 2000
+            // the OPC sampling interval is used for all three configured nodes.
+            "OpcSamplingInterval": 1000
         }
     },
+
+
     // the format below is only supported for backward compatibility. you need to ensure that the
-    // OPC UA server on the configured EndpointUrl has the namespaceindex as you expect.
-    // Please use the ExpandedNodeId syntax instead.
+    // OPC UA server on the configured EndpointUrl has the namespaceindex you expect with your configuration.
+    // please use the ExpandedNodeId syntax instead.
     {
         "EndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
         "NodeId": {


### PR DESCRIPTION
Add configuration option to control OPC sampling and publishing intervals. Monitor all nodes with same publishing interval on one subscription. Add comments. Set default sampling interval to 1000 ms.