### PR TITLE
Modified write of the secure token to use the correct path

### DIFF
--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -115,7 +115,7 @@ namespace OpcPublisher
                         deviceConnectionString = hostname + ";DeviceId=" + ApplicationName + ";SharedAccessKey=" + newDevice.Authentication.SymmetricKey.PrimaryKey;
                         Trace($"Device connection string is: {deviceConnectionString}");
                         Trace($"Adding it to device cert store.");
-                        SecureIoTHubToken.Write(ApplicationName, deviceConnectionString, IotDeviceCertStoreType, IotDeviceCertStoreType);
+                        SecureIoTHubToken.Write(ApplicationName, deviceConnectionString, IotDeviceCertStoreType, IotDeviceCertStorePath);
                     }
                     else
                     {


### PR DESCRIPTION
When writing the secure token with IoTHubMessaging incorrect storepath were passed (just a typo).