### PR TITLE
Performance optimization, update to .NETCore 2.0 and latest OPC Stack package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+dótnet: 2.0.0
 sudo: required
 dist: trusty
 addons:
@@ -6,10 +7,6 @@ addons:
     sources:
     packages:
 install:
-  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' 
-  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
-  - sudo apt-get update
-  - sudo apt-get install dotnet-dev-1.0.4 -y
 script: 
   - dotnet restore src
   - dotnet build -c Debug src

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
     sources:
     packages:
 install:
+  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' 
+  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+  - sudo apt-get update
 script: 
   - dotnet restore src
   - dotnet build -c Debug src

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: csharp
-dótnet: 2.0.0
 sudo: required
 dist: trusty
 addons:
@@ -10,6 +9,7 @@ install:
   - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' 
   - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
   - sudo apt-get update
+  - sudo apt-get install dotnet-dev-2.0.0 -y
 script: 
   - dotnet restore src
   - dotnet build -c Debug src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-sdk
+FROM microsoft/dotnet:2.0-sdk-jessie
 
 COPY /src /build/src
 

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-sdk-nanoserver
+FROM microsoft/dotnet:2.0-sdk-nanoserver
 
 COPY /src /build/src
 

--- a/Dockerfile.ssh
+++ b/Dockerfile.ssh
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-sdk
+FROM microsoft/dotnet:2.0-sdk-jessie
 
 RUN apt-get update && apt-get install -y unzip \
 	&& curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v vs2017u1 -l ~/vsdbg

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following options are supported:
 
       --pf, --publishfile=VALUE
                              the filename to configure the nodes to publish.
-                               Default: '/docker/publishednodes.json'
+                               Default: './publishednodes.json'
       --sd, --shopfloordomain=VALUE
                              the domain of the shopfloor. if specified this
                                domain is appended (delimited by a ':' to the '
@@ -214,6 +214,11 @@ The following options are supported:
                              the publisher certificate is put into the trusted
                                certificate store automatically.
                                Default: True
+      --fd, --fetchdisplayname=VALUE
+                             enable to read the display name of a published
+                               node from the server. this will increase the
+                               runtime.
+                               Default: False
       --at, --appcertstoretype=VALUE
                              the own application cert store type.
                                (allowed values: Directory, X509Store)
@@ -232,7 +237,7 @@ The following options are supported:
                              the path of the trusted cert store
                                Default (depends on store type):
                                X509Store: 'CurrentUser\UA_MachineDefault'
-                               Directory: 'CertificateStores/UA Applications'
+                               Directory: 'CertificateStores/trusted'
       --rt, --rejectedcertstoretype=VALUE
                              the rejected cert store type.
                                (allowed values: Directory, X509Store)
@@ -241,8 +246,7 @@ The following options are supported:
                              the path of the rejected cert store
                                Default (depends on store type):
                                X509Store: 'CurrentUser\UA_MachineDefault'
-                               Directory: 'CertificateStores/Rejected
-                               Certificates'
+                               Directory: 'CertificateStores/rejected'
       --it, --issuercertstoretype=VALUE
                              the trusted issuer cert store type.
                                (allowed values: Directory, X509Store)
@@ -251,8 +255,7 @@ The following options are supported:
                              the path of the trusted issuer cert store
                                Default (depends on store type):
                                X509Store: 'CurrentUser\UA_MachineDefault'
-                               Directory: 'CertificateStores/UA Certificate
-                               Authorities'
+                               Directory: 'CertificateStores/issuers'
       --dt, --devicecertstoretype=VALUE
                              the iothub device cert store type.
                                (allowed values: Directory, X509Store)
@@ -260,7 +263,7 @@ The following options are supported:
       --dp, --devicecertstorepath=VALUE
                              the path of the iot device cert store
                                Default Default (depends on store type):
-                               X509Store: 'IoTHub'
+                               X509Store: 'My'
                                Directory: 'CertificateStores/IoTHub'
       -h, --help                 show this message and exit
 
@@ -312,8 +315,11 @@ The container can now be reached by other containers via the name `publisher`ove
 Publisher uses the hostname of the machine is running on for certificate and endpoint generation. docker chooses a random hostname if there is none set by the `-h` option. Here an example to set the internal hostname of the container to `publisher`:
 
     docker run -h publisher microsoft/iot-edge-opc-publisher <applicationname> [<iothubconnectionstring>] [options]
-### Access to host volume (shared filesystem)
-In certain use cases it may make sense to use configuration information, certificate stores or log file locations from the host and not keep them in the container file system only. To achieve this you need to use the `-v` option of `docker run`.
+### Using bind mounts (shared filesystem)
+In certain use cases it may make sense to read configuration information from or write log files to locations on the host and not keep them in the container file system only. To achieve this you need to use the `-v` option of `docker run` in the bind mount mode.
+
+### Store for X509 certificates
+Storing X509 certificates does not work with bind mounts, since the permissions of the path to the store need to be `rw` for the owner. Instead you need to use the `-v` option of `docker run` in the volume mode.
 
 # Debugging the Application
 

--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -132,7 +132,6 @@ namespace OpcPublisher
                 {
                     Trace($"Create Publisher IoTHub client with device connection string: '{deviceConnectionString}' using '{IotHubProtocol}' for communication.");
                     _iotHubClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, IotHubProtocol);
-                    _iotHubClient.RetryPolicy = RetryPolicyType.Exponential_Backoff_With_Jitter;
                     _iotHubClient.OpenAsync().Wait();
                 }
                 else
@@ -164,7 +163,6 @@ namespace OpcPublisher
         public void ConnectionStringWrite(string iotHubOwnerConnectionString)
         {
             DeviceClient newClient = DeviceClient.CreateFromConnectionString(iotHubOwnerConnectionString, IotHubProtocol);
-            newClient.RetryPolicy = RetryPolicyType.Exponential_Backoff_With_Jitter;
             newClient.OpenAsync().Wait();
             SecureIoTHubToken.Write(OpcConfiguration.ApplicationName, iotHubOwnerConnectionString, IotDeviceCertStoreType, IotDeviceCertStorePath);
             _iotHubClient = newClient;

--- a/src/OpcPublisher.csproj
+++ b/src/OpcPublisher.csproj
@@ -37,9 +37,7 @@
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.5.0" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="Mono.Posix" Version="4.0.0" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="0.4.5" />
-    <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpcPublisher.csproj
+++ b/src/OpcPublisher.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.5.0" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="0.4.3" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="0.4.1" />
     <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/OpcPublisher.csproj
+++ b/src/OpcPublisher.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.5.1" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="0.4.5" />
   </ItemGroup>

--- a/src/OpcPublisher.csproj
+++ b/src/OpcPublisher.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>OpcPublisher</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>OpcPublisher</PackageId>
-    <RuntimeFrameworkVersion>1.1.2</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0</RuntimeFrameworkVersion>
     <GenerateAssemblyCompanyAttribute>true</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
     <Description>This application subscribes to a configurable set of nodes in OPC UA server systems and publish them to Azure IoTHub.</Description>
     <Company>Microsoft</Company>
-    <Version>1.1.2</Version>
+    <Version>2.0</Version>
+	<DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,7 +37,8 @@
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.5.0" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="0.4.1" />
+    <PackageReference Include="Mono.Posix" Version="4.0.0" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="0.4.5" />
     <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/OpcPublisher.sln
+++ b/src/OpcPublisher.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.travis.yml = ..\.travis.yml
 		..\appveyor.yml = ..\appveyor.yml
 		..\Dockerfile = ..\Dockerfile
+		..\Dockerfile.ssh = ..\Dockerfile.ssh
 		..\Dockerfile.Windows = ..\Dockerfile.Windows
 		..\License.txt = ..\License.txt
 		..\README.md = ..\README.md

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -688,7 +688,8 @@ namespace OpcPublisher
                             {
                                 Trace($"Hit configured missed keep alive threshold of {Program.OpcKeepAliveDisconnectThreshold}. Disconnecting the session to endpoint {session.ConfiguredEndpoint.EndpointUrl}.");
                                 session.KeepAlive -= StandardClient_KeepAlive;
-                                opcSession.Disconnect();
+                                Task disconnectTask = Task.Run(() => opcSession.Disconnect());
+                                disconnectTask.Wait();
                             }
                         }
                     }

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -322,16 +322,24 @@ namespace OpcPublisher
                                 currentNodeId = new NodeId((NodeId)item.StartNodeId);
                             }
 
-                            // get the DisplayName for the node, otherwise use the nodeId
-                            Node node = Session.ReadNode(currentNodeId);
-                            item.DisplayName = node.DisplayName.Text ?? currentNodeId.ToString();
+                            // if configured, get the DisplayName for the node, otherwise use the nodeId
+                            Node node;
+                            if (FetchOpcNodeDisplayName == true)
+                            {
+                                node = Session.ReadNode(currentNodeId);
+                                item.DisplayName = node.DisplayName.Text ?? currentNodeId.ToString();
+                            }
+                            else
+                            {
+                                item.DisplayName = currentNodeId.ToString();
+                            }
 
                             // add the new monitored item.
                             MonitoredItem monitoredItem = new MonitoredItem()
                             {
                                 StartNodeId = currentNodeId,
                                 AttributeId = item.AttributeId,
-                                DisplayName = node.DisplayName.Text,
+                                DisplayName = item.DisplayName,
                                 MonitoringMode = item.MonitoringMode,
                                 SamplingInterval = item.RequestedSamplingInterval,
                                 QueueSize = item.QueueSize,

--- a/src/OpcStackConfiguration.cs
+++ b/src/OpcStackConfiguration.cs
@@ -6,57 +6,242 @@ using System.Security.Cryptography.X509Certificates;
 namespace OpcPublisher
 {
     using System.IO;
+    using System.Threading.Tasks;
+    using static Opc.Ua.CertificateStoreType;
     using static OpcPublisher.Workarounds.TraceWorkaround;
 
     public class OpcStackConfiguration
     {
-        /// <summary>
-        /// Opc client configuration
-        /// </summary>
-        public ApplicationConfiguration Configuration;
 
-        public OpcStackConfiguration(string applicationName)
+        public static string ApplicationName
+        {
+            get => _applicationName;
+            set => _applicationName = value;
+        }
+        private static string _applicationName = "publisher";
+
+        public static string LogFileName
+        {
+            get => _logFileName;
+            set => _logFileName = value;
+        }
+        private static string _logFileName;
+
+        public static ushort PublisherServerPort
+        {
+            get => _publisherServerPort;
+            set => _publisherServerPort = value;
+        }
+        private static ushort _publisherServerPort = 62222;
+
+        public static string PublisherServerPath
+        {
+            get => _publisherServerPath;
+            set => _publisherServerPath = value;
+        }
+        private static string _publisherServerPath = "/UA/Publisher";
+
+        public static int OpcOperationTimeout
+        {
+            get => _opcOperationTimeout;
+            set => _opcOperationTimeout = value;
+        }
+        private static int _opcOperationTimeout = 120000;
+
+        public static bool TrustMyself
+        {
+            get => _trustMyself;
+            set => _trustMyself = value;
+        }
+        private static bool _trustMyself = true;
+
+        // Enable Utils.TraceMasks.OperationDetail to get output for IoTHub telemetry operations. Current: 0x287 (647), with OperationDetail: 0x2C7 (711)
+        public static int OpcStackTraceMask
+        {
+            get => _opcStackTraceMask;
+            set => _opcStackTraceMask = value;
+        }
+        private static int _opcStackTraceMask = Utils.TraceMasks.Error | Utils.TraceMasks.Security | Utils.TraceMasks.StackTrace | Utils.TraceMasks.StartStop;
+
+        public static bool OpcPublisherAutoTrustServerCerts
+        {
+            get => _opcPublisherAutoTrustServerCerts;
+            set => _opcPublisherAutoTrustServerCerts = value;
+        }
+        private static bool _opcPublisherAutoTrustServerCerts = false;
+
+        public static uint OpcSessionCreationTimeout
+        {
+            get => _opcSessionCreationTimeout;
+            set => _opcSessionCreationTimeout = value;
+        }
+        private static uint _opcSessionCreationTimeout = 10;
+
+        public static uint OpcSessionCreationBackoffMax
+        {
+            get => _opcSessionCreationBackoffMax;
+            set => _opcSessionCreationBackoffMax = value;
+        }
+        private static uint _opcSessionCreationBackoffMax = 5;
+
+        public static uint OpcKeepAliveDisconnectThreshold
+        {
+            get => _opcKeepAliveDisconnectThreshold;
+            set => _opcKeepAliveDisconnectThreshold = value;
+        }
+        private static uint _opcKeepAliveDisconnectThreshold = 5;
+
+        public static int OpcKeepAliveIntervalInSec
+        {
+            get => _opcKeepAliveIntervalInSec;
+            set => _opcKeepAliveIntervalInSec = value;
+        }
+        private static int _opcKeepAliveIntervalInSec = 2;
+
+        public static int OpcSamplingInterval
+        {
+            get => _opcSamplingInterval;
+            set => _opcSamplingInterval = value;
+        }
+        private static int _opcSamplingInterval = 1000;
+
+        public static int OpcPublishingInterval
+        {
+            get => _opcPublishingInterval;
+            set => _opcPublishingInterval = value;
+        }
+        private static int _opcPublishingInterval = 0;
+
+        public static string PublisherServerSecurityPolicy
+        {
+            get => _publisherServerSecurityPolicy;
+            set => _publisherServerSecurityPolicy = value;
+        }
+        private static string _publisherServerSecurityPolicy = SecurityPolicies.Basic128Rsa15;
+
+        public static string OpcOwnCertStoreType
+        {
+            get => _opcOwnCertStoreType;
+            set => _opcOwnCertStoreType = value;
+        }
+        private static string _opcOwnCertStoreType = X509Store;
+
+        public static string OpcOwnCertDirectoryStorePathDefault => "CertificateStores/own";
+        public static string OpcOwnCertX509StorePathDefault => "CurrentUser\\UA_MachineDefault";
+        public static string OpcOwnCertStorePath
+        {
+            get => _opcOwnCertStorePath;
+            set => _opcOwnCertStorePath = value;
+        }
+        private static string _opcOwnCertStorePath = OpcOwnCertX509StorePathDefault;
+
+        public static string OpcTrustedCertStoreType
+        {
+            get => _opcTrustedCertStoreType;
+            set => _opcTrustedCertStoreType = value;
+        }
+        private static string _opcTrustedCertStoreType = CertificateStoreType.Directory;
+
+        public static string OpcTrustedCertDirectoryStorePathDefault => "CertificateStores/trusted";
+        public static string OpcTrustedCertX509StorePathDefault => "CurrentUser\\UA_MachineDefault";
+        public static string OpcTrustedCertStorePath
+        {
+            get => _opcTrustedCertStorePath;
+            set => _opcTrustedCertStorePath = value;
+        }
+        private static string _opcTrustedCertStorePath = null;
+
+        public static string OpcRejectedCertStoreType
+        {
+            get => _opcRejectedCertStoreType;
+            set => _opcRejectedCertStoreType = value;
+        }
+        private static string _opcRejectedCertStoreType = CertificateStoreType.Directory;
+
+        public static string OpcRejectedCertDirectoryStorePathDefault => "CertificateStores/rejected";
+        public static string OpcRejectedCertX509StorePathDefault => "CurrentUser\\UA_MachineDefault";
+        public static string OpcRejectedCertStorePath
+        {
+            get => _opcRejectedCertStorePath;
+            set => _opcRejectedCertStorePath = value;
+        }
+        private static string _opcRejectedCertStorePath = OpcRejectedCertDirectoryStorePathDefault;
+
+        public static string OpcIssuerCertStoreType
+        {
+            get => _opcIssuerCertStoreType;
+            set => _opcIssuerCertStoreType = value;
+        }
+        private static string _opcIssuerCertStoreType = CertificateStoreType.Directory;
+
+        public static string OpcIssuerCertDirectoryStorePathDefault => "CertificateStores/issuers";
+        public static string OpcIssuerCertX509StorePathDefault => "CurrentUser\\UA_MachineDefault";
+        public static string OpcIssuerCertStorePath
+        {
+            get => _opcIssuerCertStorePath;
+            set => _opcIssuerCertStorePath = value;
+        }
+        private static string _opcIssuerCertStorePath = OpcIssuerCertDirectoryStorePathDefault;
+
+        public static int LdsRegistrationInterval
+        {
+            get => _ldsRegistrationInterval;
+            set => _ldsRegistrationInterval = value;
+        }
+        private static int _ldsRegistrationInterval = 0;
+
+        public static ApplicationConfiguration PublisherOpcApplicationConfiguration
+        {
+            get => _configuration;
+        }
+        private static ApplicationConfiguration _configuration;
+
+        /// <summary>
+        /// Configures all OPC stack settings
+        /// </summary>
+        public async Task ConfigureAsync()
         {
             // Instead of using a Config.xml we configure everything programmatically.
 
             //
             // OPC UA Application configuration
             //
-            Configuration = new ApplicationConfiguration();
+            _configuration = new ApplicationConfiguration();
+
             // Passed in as command line argument
-            Configuration.ApplicationName = applicationName;
-            Configuration.ApplicationUri = $"urn:{Utils.GetHostName()}:{Configuration.ApplicationName}:microsoft:";
-            Configuration.ProductUri = "https://github.com/Azure/iot-edge-opc-publisher";
-            Configuration.ApplicationType = ApplicationType.ClientAndServer;
+            _configuration.ApplicationName = _applicationName;
+            _configuration.ApplicationUri = $"urn:{Utils.GetHostName()}:{_configuration.ApplicationName}:microsoft:";
+            _configuration.ProductUri = "https://github.com/Azure/iot-edge-opc-publisher";
+            _configuration.ApplicationType = ApplicationType.ClientAndServer;
 
 
             //
             // Security configuration
             //
-            Configuration.SecurityConfiguration = new SecurityConfiguration();
+            _configuration.SecurityConfiguration = new SecurityConfiguration();
 
             // Application certificate
-            Configuration.SecurityConfiguration.ApplicationCertificate = new CertificateIdentifier();
-            Configuration.SecurityConfiguration.ApplicationCertificate.StoreType = Program.OpcOwnCertStoreType;
-            Configuration.SecurityConfiguration.ApplicationCertificate.StorePath = Program.OpcOwnCertStorePath;
-            Configuration.SecurityConfiguration.ApplicationCertificate.SubjectName = Configuration.ApplicationName;
-            Trace($"Application Certificate store type is: {Configuration.SecurityConfiguration.ApplicationCertificate.StoreType}");
-            Trace($"Application Certificate store path is: {Configuration.SecurityConfiguration.ApplicationCertificate.StorePath}");
-            Trace($"Application Certificate subject name is: {Configuration.SecurityConfiguration.ApplicationCertificate.SubjectName}");
+            _configuration.SecurityConfiguration.ApplicationCertificate = new CertificateIdentifier();
+            _configuration.SecurityConfiguration.ApplicationCertificate.StoreType = _opcOwnCertStoreType;
+            _configuration.SecurityConfiguration.ApplicationCertificate.StorePath = _opcOwnCertStorePath;
+            _configuration.SecurityConfiguration.ApplicationCertificate.SubjectName = _configuration.ApplicationName;
+            Trace($"Application Certificate store type is: {_configuration.SecurityConfiguration.ApplicationCertificate.StoreType}");
+            Trace($"Application Certificate store path is: {_configuration.SecurityConfiguration.ApplicationCertificate.StorePath}");
+            Trace($"Application Certificate subject name is: {_configuration.SecurityConfiguration.ApplicationCertificate.SubjectName}");
 
             // Use existing certificate, if it is there.
-            X509Certificate2 certificate = Configuration.SecurityConfiguration.ApplicationCertificate.Find(true).Result;
+            X509Certificate2 certificate = await _configuration.SecurityConfiguration.ApplicationCertificate.Find(true);
             if (certificate == null)
             {
                 Trace($"No existing Application certificate found. Create a self-signed Application certificate valid from yesterday for {CertificateFactory.defaultLifeTime} months,");
                 Trace($"with a {CertificateFactory.defaultKeySize} bit key and {CertificateFactory.defaultHashSize} bit hash.");
                 certificate = CertificateFactory.CreateCertificate(
-                    Configuration.SecurityConfiguration.ApplicationCertificate.StoreType,
-                    Configuration.SecurityConfiguration.ApplicationCertificate.StorePath,
+                    _configuration.SecurityConfiguration.ApplicationCertificate.StoreType,
+                    _configuration.SecurityConfiguration.ApplicationCertificate.StorePath,
                     null,
-                    Configuration.ApplicationUri,
-                    Configuration.ApplicationName,
-                    Configuration.ApplicationName,
+                    _configuration.ApplicationUri,
+                    _configuration.ApplicationName,
+                    _configuration.ApplicationName,
                     null,
                     CertificateFactory.defaultKeySize,
                     DateTime.UtcNow - TimeSpan.FromDays(1),
@@ -66,81 +251,81 @@ namespace OpcPublisher
                     null,
                     null
                     );
-                Configuration.SecurityConfiguration.ApplicationCertificate.Certificate = certificate ?? throw new Exception("OPC UA application certificate could not be created! Cannot continue without it!");
+                _configuration.SecurityConfiguration.ApplicationCertificate.Certificate = certificate ?? throw new Exception("OPC UA application certificate could not be created! Cannot continue without it!");
             }
             else
             {
                 Trace("Application certificate found in Application Certificate Store");
             }
-            Configuration.ApplicationUri = Utils.GetApplicationUriFromCertificate(certificate);
-            Trace($"Application certificate is for Application URI '{Configuration.ApplicationUri}', Application '{Configuration.ApplicationName} and has Subject '{Configuration.ApplicationName}'");
+            _configuration.ApplicationUri = Utils.GetApplicationUriFromCertificate(certificate);
+            Trace($"Application certificate is for Application URI '{_configuration.ApplicationUri}', Application '{_configuration.ApplicationName} and has Subject '{_configuration.ApplicationName}'");
 
             // TrustedIssuerCertificates
-            Configuration.SecurityConfiguration.TrustedIssuerCertificates = new CertificateTrustList();
-            Configuration.SecurityConfiguration.TrustedIssuerCertificates.StoreType = Program.OpcIssuerCertStoreType;
-            Configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath = Program.OpcIssuerCertStorePath;
-            Trace($"Trusted Issuer store type is: {Configuration.SecurityConfiguration.TrustedIssuerCertificates.StoreType}");
-            Trace($"Trusted Issuer Certificate store path is: {Configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath}");
+            _configuration.SecurityConfiguration.TrustedIssuerCertificates = new CertificateTrustList();
+            _configuration.SecurityConfiguration.TrustedIssuerCertificates.StoreType = _opcIssuerCertStoreType;
+            _configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath = _opcIssuerCertStorePath;
+            Trace($"Trusted Issuer store type is: {_configuration.SecurityConfiguration.TrustedIssuerCertificates.StoreType}");
+            Trace($"Trusted Issuer Certificate store path is: {_configuration.SecurityConfiguration.TrustedIssuerCertificates.StorePath}");
 
             // TrustedPeerCertificates
-            Configuration.SecurityConfiguration.TrustedPeerCertificates = new CertificateTrustList();
-            Configuration.SecurityConfiguration.TrustedPeerCertificates.StoreType = Program.OpcTrustedCertStoreType;
-            if (string.IsNullOrEmpty(Program.OpcTrustedCertStorePath))
+            _configuration.SecurityConfiguration.TrustedPeerCertificates = new CertificateTrustList();
+            _configuration.SecurityConfiguration.TrustedPeerCertificates.StoreType = _opcTrustedCertStoreType;
+            if (string.IsNullOrEmpty(_opcTrustedCertStorePath))
             {
                 // Set default.
-                Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath = Program.OpcTrustedCertStoreType == CertificateStoreType.X509Store ? Program.OpcTrustedCertX509StorePathDefault : Program.OpcTrustedCertDirectoryStorePathDefault;
+                _configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath = _opcTrustedCertStoreType == X509Store ? OpcTrustedCertX509StorePathDefault : OpcTrustedCertDirectoryStorePathDefault;
                 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("_TPC_SP")))
                 {
                     // Use environment variable.
-                    Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath = Environment.GetEnvironmentVariable("_TPC_SP");
+                    _configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath = Environment.GetEnvironmentVariable("_TPC_SP");
                 }
             }
             else
             {
-                Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath = Program.OpcTrustedCertStorePath;
+                _configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath = _opcTrustedCertStorePath;
             }
-            Trace($"Trusted Peer Certificate store type is: {Configuration.SecurityConfiguration.TrustedPeerCertificates.StoreType}");
-            Trace($"Trusted Peer Certificate store path is: {Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
+            Trace($"Trusted Peer Certificate store type is: {_configuration.SecurityConfiguration.TrustedPeerCertificates.StoreType}");
+            Trace($"Trusted Peer Certificate store path is: {_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
 
             // RejectedCertificateStore
-            Configuration.SecurityConfiguration.RejectedCertificateStore = new CertificateTrustList();
-            Configuration.SecurityConfiguration.RejectedCertificateStore.StoreType = Program.OpcRejectedCertStoreType;
-            Configuration.SecurityConfiguration.RejectedCertificateStore.StorePath = Program.OpcRejectedCertStorePath;
-            Trace($"Rejected certificate store type is: {Configuration.SecurityConfiguration.RejectedCertificateStore.StoreType}");
-            Trace($"Rejected Certificate store path is: {Configuration.SecurityConfiguration.RejectedCertificateStore.StorePath}");
+            _configuration.SecurityConfiguration.RejectedCertificateStore = new CertificateTrustList();
+            _configuration.SecurityConfiguration.RejectedCertificateStore.StoreType = _opcRejectedCertStoreType;
+            _configuration.SecurityConfiguration.RejectedCertificateStore.StorePath = _opcRejectedCertStorePath;
+            Trace($"Rejected certificate store type is: {_configuration.SecurityConfiguration.RejectedCertificateStore.StoreType}");
+            Trace($"Rejected Certificate store path is: {_configuration.SecurityConfiguration.RejectedCertificateStore.StorePath}");
 
             // AutoAcceptUntrustedCertificates
             // This is a security risk and should be set to true only for debugging purposes.
-            Configuration.SecurityConfiguration.AutoAcceptUntrustedCertificates = false;
+            _configuration.SecurityConfiguration.AutoAcceptUntrustedCertificates = false;
 
             // RejectSHA1SignedCertificates
             // We allow SHA1 certificates for now as many OPC Servers still use them
-            Configuration.SecurityConfiguration.RejectSHA1SignedCertificates = false;
-            Trace($"Rejection of SHA1 signed certificates is {(Configuration.SecurityConfiguration.RejectSHA1SignedCertificates ? "enabled" : "disabled")}");
+            _configuration.SecurityConfiguration.RejectSHA1SignedCertificates = false;
+            Trace($"Rejection of SHA1 signed certificates is {(_configuration.SecurityConfiguration.RejectSHA1SignedCertificates ? "enabled" : "disabled")}");
 
             // MinimunCertificatesKeySize
             // We allow a minimum key size of 1024 bit, as many OPC UA servers still use them
-            Configuration.SecurityConfiguration.MinimumCertificateKeySize = 1024;
-            Trace($"Minimum certificate key size set to {Configuration.SecurityConfiguration.MinimumCertificateKeySize}");
+            _configuration.SecurityConfiguration.MinimumCertificateKeySize = 1024;
+            Trace($"Minimum certificate key size set to {_configuration.SecurityConfiguration.MinimumCertificateKeySize}");
 
             // We make the default reference stack behavior configurable to put our own certificate into the trusted peer store.
-            if (Program.TrustMyself)
+            if (_trustMyself)
             {
                 // Ensure it is trusted
                 try
                 {
-                    ICertificateStore store = Configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore();
+                    ICertificateStore store = _configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore();
                     if (store == null)
                     {
-                        Trace($"Could not open trusted peer store. StorePath={Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
+                        Trace($"Could not open trusted peer store. StorePath={_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
                     }
                     else
                     {
                         try
                         {
-                            Trace($"Adding publisher certificate to trusted peer store. StorePath={Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
+                            Trace($"Adding publisher certificate to trusted peer store. StorePath={_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
                             X509Certificate2 publicKey = new X509Certificate2(certificate.RawData);
-                            store.Add(publicKey).Wait();
+                            await store.Add(publicKey);
                         }
                         finally
                         {
@@ -150,7 +335,7 @@ namespace OpcPublisher
                 }
                 catch (Exception e)
                 {
-                    Trace(e, $"Could not add publisher certificate to trusted peer store. StorePath={Configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
+                    Trace(e, $"Could not add publisher certificate to trusted peer store. StorePath={_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
                 }
             }
             else
@@ -163,24 +348,24 @@ namespace OpcPublisher
             // TransportConfigurations
             //
 
-            Configuration.TransportQuotas = new TransportQuotas();
+            _configuration.TransportQuotas = new TransportQuotas();
             // the OperationTimeout should be twice the minimum value for PublishingInterval * KeepAliveCount, so set to 120s
-            Configuration.TransportQuotas.OperationTimeout = Program.OpcOperationTimeout;
-            Trace($"OperationTimeout set to {Configuration.TransportQuotas.OperationTimeout}");
+            _configuration.TransportQuotas.OperationTimeout = _opcOperationTimeout;
+            Trace($"OperationTimeout set to {_configuration.TransportQuotas.OperationTimeout}");
 
 
             //
             // ServerConfiguration
             //
-            Configuration.ServerConfiguration = new ServerConfiguration();
+            _configuration.ServerConfiguration = new ServerConfiguration();
 
             // BaseAddresses
-            if (Configuration.ServerConfiguration.BaseAddresses.Count == 0)
+            if (_configuration.ServerConfiguration.BaseAddresses.Count == 0)
             {
                 // We do not use the localhost replacement mechanism of the configuration loading, to immediately show the base address here
-                Configuration.ServerConfiguration.BaseAddresses.Add($"opc.tcp://{Utils.GetHostName()}:{Program.PublisherServerPort}{Program.PublisherServerPath}");
+                _configuration.ServerConfiguration.BaseAddresses.Add($"opc.tcp://{Utils.GetHostName()}:{_publisherServerPort}{_publisherServerPath}");
             }
-            foreach (var endpoint in Configuration.ServerConfiguration.BaseAddresses)
+            foreach (var endpoint in _configuration.ServerConfiguration.BaseAddresses)
             {
                 Trace($"Publisher server base address: {endpoint}");
             }
@@ -192,53 +377,53 @@ namespace OpcPublisher
                 SecurityMode = MessageSecurityMode.SignAndEncrypt,
                 SecurityPolicyUri = SecurityPolicies.Basic256Sha256
             };
-            Configuration.ServerConfiguration.SecurityPolicies.Add(newPolicy);
+            _configuration.ServerConfiguration.SecurityPolicies.Add(newPolicy);
             Trace($"Security policy {newPolicy.SecurityPolicyUri} with mode {newPolicy.SecurityMode} added");
 
             // MaxRegistrationInterval
-            Configuration.ServerConfiguration.MaxRegistrationInterval = Program.LdsRegistrationInterval;
-            Trace($"LDS(-ME) registration intervall set to {Program.LdsRegistrationInterval} ms (0 means no registration)");
+            _configuration.ServerConfiguration.MaxRegistrationInterval = _ldsRegistrationInterval;
+            Trace($"LDS(-ME) registration intervall set to {_ldsRegistrationInterval} ms (0 means no registration)");
 
             //
             // TraceConfiguration
             //
-            Configuration.TraceConfiguration = new TraceConfiguration();
+            _configuration.TraceConfiguration = new TraceConfiguration();
             // Due to a bug in a stack we need to do console output ourselve.
             Utils.SetTraceOutput(Utils.TraceOutput.FileOnly);
 
             // OutputFilePath
-            if (string.IsNullOrEmpty(Program.LogFileName))
+            if (string.IsNullOrEmpty(_logFileName))
             {
                 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("_GW_LOGP")))
                 {
-                    Configuration.TraceConfiguration.OutputFilePath = Environment.GetEnvironmentVariable("_GW_LOGP");
+                    _configuration.TraceConfiguration.OutputFilePath = Environment.GetEnvironmentVariable("_GW_LOGP");
                 }
                 else
                 {
-                    Configuration.TraceConfiguration.OutputFilePath = "./Logs/" + Configuration.ApplicationName + ".log.txt";
+                    _configuration.TraceConfiguration.OutputFilePath = "./Logs/" + _configuration.ApplicationName + ".log.txt";
                 }
             }
             else
             {
-                Configuration.TraceConfiguration.OutputFilePath = Program.LogFileName;
+                _configuration.TraceConfiguration.OutputFilePath = _logFileName;
             }
 
             // DeleteOnLoad
-            Configuration.TraceConfiguration.DeleteOnLoad = false;
+            _configuration.TraceConfiguration.DeleteOnLoad = false;
 
             // TraceMasks
-            Configuration.TraceConfiguration.TraceMasks = Program.OpcStackTraceMask;
+            _configuration.TraceConfiguration.TraceMasks = _opcStackTraceMask;
 
             // Apply the settings
-            Configuration.TraceConfiguration.ApplySettings();
-            Trace($"Current directory is: {Directory.GetCurrentDirectory()}");
-            Trace($"Log file is: {Utils.GetAbsoluteFilePath(Configuration.TraceConfiguration.OutputFilePath, true, false, false, true)}");
-            Trace($"opcstacktracemask set to: 0x{Program.OpcStackTraceMask:X} ({Program.OpcStackTraceMask})");
+            _configuration.TraceConfiguration.ApplySettings();
+            Trace($"Current directory is: {System.IO.Directory.GetCurrentDirectory()}");
+            Trace($"Log file is: {Utils.GetAbsoluteFilePath(_configuration.TraceConfiguration.OutputFilePath, true, false, false, true)}");
+            Trace($"opcstacktracemask set to: 0x{_opcStackTraceMask:X} ({_opcStackTraceMask})");
 
-            Configuration.ClientConfiguration = new ClientConfiguration();
+            _configuration.ClientConfiguration = new ClientConfiguration();
 
             // validate the configuration now
-            Configuration.Validate(Configuration.ApplicationType).Wait();
+            await _configuration.Validate(_configuration.ApplicationType);
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -14,88 +14,48 @@ namespace OpcPublisher
     using Opc.Ua;
     using Opc.Ua.Server;
     using System.Text.RegularExpressions;
+    using static IotHubMessaging;
     using static Opc.Ua.CertificateStoreType;
     using static OpcPublisher.Workarounds.TraceWorkaround;
+    using static OpcSession;
+    using static OpcStackConfiguration;
     using static System.Console;
 
     public class Program
     {
-        //
-        // Publisher app related
-        //
-        public static int PublisherSessionConnectWaitSec = 10;
         public static List<OpcSession> OpcSessions = new List<OpcSession>();
-        public static SemaphoreSlim OpcSessionsSemaphore = new SemaphoreSlim(1);
+        public static SemaphoreSlim OpcSessionsListSemaphore = new SemaphoreSlim(1);
         public static List<PublisherConfigFileEntry> PublisherConfigFileEntries = new List<PublisherConfigFileEntry>();
         public static List<NodeToPublishConfig> PublishConfig = new List<NodeToPublishConfig>();
-        public static string NodesToPublishAbsFilenameDefault = $"{System.IO.Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}publishednodes.json";
-        public static string NodesToPublishAbsFilename;
         public static SemaphoreSlim PublishDataSemaphore = new SemaphoreSlim(1);
-        public static string ShopfloorDomain;
-        public static bool VerboseConsole;
-        public static bool PublisherShutdownInProgress = false;
+        public static IotHubMessaging IotHubCommunication;
+
+        public static string NodesToPublishAbsFilename
+        {
+            get => _nodesToPublishAbsFilename;
+            set => _nodesToPublishAbsFilename = value;
+        }
+        private static string _nodesToPublishAbsFilename;
+
+        public static bool PublisherShutdownInProgress
+        {
+            get => _publisherShutdownInProgress;
+            set => _publisherShutdownInProgress = value;
+        }
+        private static bool _publisherShutdownInProgress = false;
+
+        public static uint PublisherShutdownWaitPeriod
+        {
+            get => _publisherShutdownWaitPeriod;
+            set => _publisherShutdownWaitPeriod = value;
+        }
+        private static uint _publisherShutdownWaitPeriod = 10;
+
         private static PublisherServer _publisherServer;
         private static DateTime _lastServerSessionEventTime = DateTime.UtcNow;
-        public static uint PublisherShutdownWaitPeriod = 10;
-
-        //
-        // IoTHub related
-        //
-        private static string _IotHubOwnerConnectionString;
-        public static Microsoft.Azure.Devices.Client.TransportType IotHubProtocol = Microsoft.Azure.Devices.Client.TransportType.Mqtt;
-        public static IotHubMessaging IotHubCommunication;
-        private static uint _MaxSizeOfIoTHubMessageBytes = 4096;
-        private static int _DefaultSendIntervalSeconds = 1;
-
-        public static string IotDeviceCertStoreType = X509Store;
-        private const string _iotDeviceCertDirectoryStorePathDefault = "CertificateStores/IoTHub";
-        private const string _iotDeviceCertX509StorePathDefault = "IoTHub";
-        public static string IotDeviceCertStorePath = _iotDeviceCertX509StorePathDefault;
-
-        //
-        // OPC component related
-        //
-        public static ApplicationConfiguration OpcConfiguration = null;
-        public static string ApplicationName;
-        public static string LogFileName;
-        public static ushort PublisherServerPort = 62222;
-        public static string PublisherServerPath = "/UA/Publisher";
-        public static int LdsRegistrationInterval = 0;
-        public static int OpcOperationTimeout = 120000;
-        public static bool TrustMyself = true;
-        // Enable Utils.TraceMasks.OperationDetail to get output for IoTHub telemetry operations. Current: 0x287 (647), with OperationDetail: 0x2C7 (711)
-        public static int OpcStackTraceMask = Utils.TraceMasks.Error | Utils.TraceMasks.Security | Utils.TraceMasks.StackTrace | Utils.TraceMasks.StartStop;
-        public static bool OpcPublisherAutoTrustServerCerts = false;
-        public static uint OpcSessionCreationTimeout = 10;
-        public static uint OpcSessionCreationBackoffMax = 5;
-        public static uint OpcKeepAliveDisconnectThreshold = 5;
-        public static int OpcKeepAliveIntervalInSec = 2;
-        public static int OpcSamplingInterval = 1000;
-        public static int OpcPublishingInterval = 0;
-        public static bool FetchOpcNodeDisplayName = false;
-
-        public static string PublisherServerSecurityPolicy = SecurityPolicies.Basic128Rsa15;
-
-        public static string OpcOwnCertStoreType = X509Store;
-        private const string _opcOwnCertDirectoryStorePathDefault = "CertificateStores/own";
-        private const string _opcOwnCertX509StorePathDefault = "CurrentUser\\UA_MachineDefault";
-        public static string OpcOwnCertStorePath = _opcOwnCertX509StorePathDefault;
-
-        public static string OpcTrustedCertStoreType = Directory;
-        public static string OpcTrustedCertDirectoryStorePathDefault = "CertificateStores/UA Applications";
-        public static string OpcTrustedCertX509StorePathDefault = "CurrentUser\\UA_MachineDefault";
-        public static string OpcTrustedCertStorePath = null;
-
-        public static string OpcRejectedCertStoreType = Directory;
-        private const string _opcRejectedCertDirectoryStorePathDefault = "CertificateStores/Rejected Certificates";
-        private const string _opcRejectedCertX509StorePathDefault = "CurrentUser\\UA_MachineDefault";
-        public static string OpcRejectedCertStorePath = _opcRejectedCertDirectoryStorePathDefault;
-
-        public static string OpcIssuerCertStoreType = Directory;
-        private const string _opcIssuerCertDirectoryStorePathDefault = "CertificateStores/UA Certificate Authorities";
-        private const string _opcIssuerCertX509StorePathDefault = "CurrentUser\\UA_MachineDefault";
-        public static string OpcIssuerCertStorePath = _opcIssuerCertDirectoryStorePathDefault;
-
+        private static bool _opcTraceInitialized = false;
+        private static int _publisherSessionConnectWaitSec = 10;
+        private static string _nodesToPublishAbsFilenameDefault = $"{System.IO.Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}publishednodes.json";
 
         /// <summary>
         /// Usage message.
@@ -130,9 +90,19 @@ namespace OpcPublisher
             options.WriteOptionDescriptions(Console.Out);
         }
 
+        /// <summary>
+        /// Synchronous main method of the app.
+        /// </summary>
         public static void Main(string[] args)
         {
-            var opcTraceInitialized = false;
+            MainAsync(args).Wait();
+        }
+
+        /// <summary>
+        /// Asynchronous part of the main method of the app.
+        /// </summary>
+        public async static Task MainAsync(string[] args)
+        {
             try
             {
                 var shouldShowHelp = false;
@@ -140,7 +110,7 @@ namespace OpcPublisher
                 // command line options configuration
                 Mono.Options.OptionSet options = new Mono.Options.OptionSet {
                     // Publishing configuration options
-                    { "pf|publishfile=", $"the filename to configure the nodes to publish.\nDefault: '{NodesToPublishAbsFilenameDefault}'", (string p) => NodesToPublishAbsFilename = p },
+                    { "pf|publishfile=", $"the filename to configure the nodes to publish.\nDefault: '{_nodesToPublishAbsFilenameDefault}'", (string p) => _nodesToPublishAbsFilename = p },
                     { "sd|shopfloordomain=", $"the domain of the shopfloor. if specified this domain is appended (delimited by a ':' to the 'ApplicationURI' property when telemetry is sent to IoTHub.\n" +
                             "The value must follow the syntactical rules of a DNS hostname.\nDefault: not set", (string s) => {
                             Regex domainNameRegex = new Regex("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
@@ -154,10 +124,10 @@ namespace OpcPublisher
                             }
                         }
                      },
-                    { "sw|sessionconnectwait=", $"specify the wait time in seconds publisher is trying to connect to disconnected endpoints and starts monitoring unmonitored items\nMin: 10\nDefault: {PublisherSessionConnectWaitSec}", (int i) => {
+                    { "sw|sessionconnectwait=", $"specify the wait time in seconds publisher is trying to connect to disconnected endpoints and starts monitoring unmonitored items\nMin: 10\nDefault: {_publisherSessionConnectWaitSec}", (int i) => {
                             if (i > 10)
                             {
-                                PublisherSessionConnectWaitSec = i;
+                                _publisherSessionConnectWaitSec = i;
                             }
                             else
                             {
@@ -171,10 +141,10 @@ namespace OpcPublisher
                     { "ih|iothubprotocol=", $"the protocol to use for communication with Azure IoTHub (allowed values: {string.Join(", ", Enum.GetNames(IotHubProtocol.GetType()))}).\nDefault: {Enum.GetName(IotHubProtocol.GetType(), IotHubProtocol)}",
                         (Microsoft.Azure.Devices.Client.TransportType p) => IotHubProtocol = p
                     },
-                    { "ms|iothubmessagesize=", $"the max size of a message which can be send to IoTHub. when telemetry of this size is available it will be sent.\n0 will enforce immediate send when telemetry is available\nMin: 0\nMax: 256 * 1024\nDefault: {_MaxSizeOfIoTHubMessageBytes}", (uint u) => {
+                    { "ms|iothubmessagesize=", $"the max size of a message which can be send to IoTHub. when telemetry of this size is available it will be sent.\n0 will enforce immediate send when telemetry is available\nMin: 0\nMax: 256 * 1024\nDefault: {MaxSizeOfIoTHubMessageBytes}", (uint u) => {
                             if (u >= 0 && u <= 256 * 1024)
                             {
-                                _MaxSizeOfIoTHubMessageBytes = u;
+                                MaxSizeOfIoTHubMessageBytes = u;
                             }
                             else
                             {
@@ -182,10 +152,10 @@ namespace OpcPublisher
                             }
                         }
                     },
-                    { "si|iothubsendinterval=", $"the interval in seconds when telemetry should be send to IoTHub. If 0, then only the iothubmessagesize parameter controls when telemetry is sent.\nDefault: '{_DefaultSendIntervalSeconds}'", (int i) => {
+                    { "si|iothubsendinterval=", $"the interval in seconds when telemetry should be send to IoTHub. If 0, then only the iothubmessagesize parameter controls when telemetry is sent.\nDefault: '{DefaultSendIntervalSeconds}'", (int i) => {
                             if (i >= 0)
                             {
-                                _DefaultSendIntervalSeconds = i;
+                                DefaultSendIntervalSeconds = i;
                             }
                             else
                             {
@@ -279,7 +249,7 @@ namespace OpcPublisher
                             }
                         }
                     },
-                    { "st|opcstacktracemask=", $"the trace mask for the OPC stack. See github OPC .NET stack for definitions.\nTo enable IoTHub telemetry tracing set it to 711.\nDefault: {OpcStackTraceMask:X}  ({Program.OpcStackTraceMask})", (int i) => {
+                    { "st|opcstacktracemask=", $"the trace mask for the OPC stack. See github OPC .NET stack for definitions.\nTo enable IoTHub telemetry tracing set it to 711.\nDefault: {OpcStackTraceMask:X}  ({OpcStackTraceMask})", (int i) => {
                             if (i >= 0)
                             {
                                 OpcStackTraceMask = i;
@@ -303,7 +273,7 @@ namespace OpcPublisher
                             if (s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) || s.Equals(Directory, StringComparison.OrdinalIgnoreCase))
                             {
                                 OpcOwnCertStoreType = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? X509Store : Directory;
-                                OpcOwnCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? _opcOwnCertX509StorePathDefault : _opcOwnCertDirectoryStorePathDefault;
+                                OpcOwnCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? OpcOwnCertX509StorePathDefault : OpcOwnCertDirectoryStorePathDefault;
                             }
                             else
                             {
@@ -312,8 +282,8 @@ namespace OpcPublisher
                         }
                     },
                     { "ap|appcertstorepath=", $"the path where the own application cert should be stored\nDefault (depends on store type):\n" +
-                            $"X509Store: '{_opcOwnCertX509StorePathDefault}'\n" +
-                            $"Directory: '{_opcOwnCertDirectoryStorePathDefault}'", (string s) => OpcOwnCertStorePath = s
+                            $"X509Store: '{OpcOwnCertX509StorePathDefault}'\n" +
+                            $"Directory: '{OpcOwnCertDirectoryStorePathDefault}'", (string s) => OpcOwnCertStorePath = s
                     },
 
                     // trusted cert store options
@@ -340,7 +310,7 @@ namespace OpcPublisher
                             if (s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) || s.Equals(Directory, StringComparison.OrdinalIgnoreCase))
                             {
                                 OpcRejectedCertStoreType = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? X509Store : Directory;
-                                OpcRejectedCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? _opcRejectedCertX509StorePathDefault : _opcRejectedCertDirectoryStorePathDefault;
+                                OpcRejectedCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? OpcRejectedCertX509StorePathDefault : OpcRejectedCertDirectoryStorePathDefault;
                             }
                             else
                             {
@@ -349,8 +319,8 @@ namespace OpcPublisher
                         }
                     },
                     { "rp|rejectedcertstorepath=", $"the path of the rejected cert store\nDefault (depends on store type):\n" +
-                            $"X509Store: '{_opcRejectedCertX509StorePathDefault}'\n" +
-                            $"Directory: '{_opcRejectedCertDirectoryStorePathDefault}'", (string s) => OpcRejectedCertStorePath = s
+                            $"X509Store: '{OpcRejectedCertX509StorePathDefault}'\n" +
+                            $"Directory: '{OpcRejectedCertDirectoryStorePathDefault}'", (string s) => OpcRejectedCertStorePath = s
                     },
 
                     // issuer cert store options
@@ -359,7 +329,7 @@ namespace OpcPublisher
                             if (s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) || s.Equals(Directory, StringComparison.OrdinalIgnoreCase))
                             {
                                 OpcIssuerCertStoreType = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? X509Store : Directory;
-                                OpcIssuerCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? _opcIssuerCertX509StorePathDefault : _opcIssuerCertDirectoryStorePathDefault;
+                                OpcIssuerCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? OpcIssuerCertX509StorePathDefault : OpcIssuerCertDirectoryStorePathDefault;
                             }
                             else
                             {
@@ -368,8 +338,8 @@ namespace OpcPublisher
                         }
                     },
                     { "ip|issuercertstorepath=", $"the path of the trusted issuer cert store\nDefault (depends on store type):\n" +
-                            $"X509Store: '{_opcIssuerCertX509StorePathDefault}'\n" +
-                            $"Directory: '{_opcIssuerCertDirectoryStorePathDefault}'", (string s) => OpcIssuerCertStorePath = s
+                            $"X509Store: '{OpcIssuerCertX509StorePathDefault}'\n" +
+                            $"Directory: '{OpcIssuerCertDirectoryStorePathDefault}'", (string s) => OpcIssuerCertStorePath = s
                     },
 
                     // device connection string cert store options
@@ -377,7 +347,7 @@ namespace OpcPublisher
                             if (s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) || s.Equals(Directory, StringComparison.OrdinalIgnoreCase))
                             {
                                 IotDeviceCertStoreType = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? X509Store : Directory;
-                                IotDeviceCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? _iotDeviceCertX509StorePathDefault : _iotDeviceCertDirectoryStorePathDefault;
+                                IotDeviceCertStorePath = s.Equals(X509Store, StringComparison.OrdinalIgnoreCase) ? IotDeviceCertX509StorePathDefault : IotDeviceCertDirectoryStorePathDefault;
                             }
                             else
                             {
@@ -386,8 +356,8 @@ namespace OpcPublisher
                         }
                     },
                     { "dp|devicecertstorepath=", $"the path of the iot device cert store\nDefault Default (depends on store type):\n" +
-                            $"X509Store: '{_iotDeviceCertX509StorePathDefault}'\n" +
-                            $"Directory: '{_iotDeviceCertDirectoryStorePathDefault}'", (string s) => IotDeviceCertStorePath = s
+                            $"X509Store: '{IotDeviceCertX509StorePathDefault}'\n" +
+                            $"Directory: '{IotDeviceCertDirectoryStorePathDefault}'", (string s) => IotDeviceCertStorePath = s
                     },
 
                     // misc
@@ -418,23 +388,23 @@ namespace OpcPublisher
                 else if (arguments.Count == 2)
                 {
                     ApplicationName = arguments[0];
-                    _IotHubOwnerConnectionString = arguments[1];
+                    IotHubOwnerConnectionString = arguments[1];
                 }
                 else if (arguments.Count == 1)
                 {
                     ApplicationName = arguments[0];
                 }
-                else {
+                else
+                {
                     ApplicationName = Utils.GetHostName();
                 }
 
                 WriteLine("Publisher is starting up...");
 
                 // init OPC configuration and tracing
-                Init(OpcStackTraceMask, VerboseConsole);
-                OpcStackConfiguration opcStackConfiguration = new OpcStackConfiguration(ApplicationName);
-                opcTraceInitialized = true;
-                OpcConfiguration = opcStackConfiguration.Configuration;
+                OpcStackConfiguration opcStackConfiguration = new OpcStackConfiguration();
+                await opcStackConfiguration.ConfigureAsync();
+                _opcTraceInitialized = true;
 
                 // log shopfloor domain setting
                 if (string.IsNullOrEmpty(ShopfloorDomain))
@@ -450,20 +420,20 @@ namespace OpcPublisher
                 if (OpcPublisherAutoTrustServerCerts)
                 {
                     Trace("Publisher configured to auto trust server certificates of the servers it is connecting to.");
-                    OpcConfiguration.CertificateValidator.CertificateValidation += new CertificateValidationEventHandler(CertificateValidator_AutoTrustServerCerts);
+                    PublisherOpcApplicationConfiguration.CertificateValidator.CertificateValidation += new CertificateValidationEventHandler(CertificateValidator_AutoTrustServerCerts);
                 }
                 else
                 {
                     Trace("Publisher configured to not auto trust server certificates. When connecting to servers, you need to manually copy the rejected server certs to the trusted store to trust them.");
-                    OpcConfiguration.CertificateValidator.CertificateValidation += new CertificateValidationEventHandler(CertificateValidator_Default);
+                    PublisherOpcApplicationConfiguration.CertificateValidator.CertificateValidation += new CertificateValidationEventHandler(CertificateValidator_Default);
                 }
 
                 // start our server interface
                 try
                 {
-                    Trace($"Starting server on endpoint {OpcConfiguration.ServerConfiguration.BaseAddresses[0].ToString()} ...");
+                    Trace($"Starting server on endpoint {PublisherOpcApplicationConfiguration.ServerConfiguration.BaseAddresses[0].ToString()} ...");
                     _publisherServer = new PublisherServer();
-                    _publisherServer.Start(OpcConfiguration);
+                    _publisherServer.Start(PublisherOpcApplicationConfiguration);
                     Trace("Server started.");
                 }
                 catch (Exception e)
@@ -476,20 +446,20 @@ namespace OpcPublisher
                 // get information on the nodes to publish and validate the json by deserializing it.
                 try
                 {
-                    PublishDataSemaphore.Wait(); 
-                    if (string.IsNullOrEmpty(NodesToPublishAbsFilename))
+                    await PublishDataSemaphore.WaitAsync();
+                    if (string.IsNullOrEmpty(_nodesToPublishAbsFilename))
                     {
                         // check if we have an env variable specifying the published nodes path, otherwise use the default
-                        NodesToPublishAbsFilename = NodesToPublishAbsFilenameDefault;
+                        _nodesToPublishAbsFilename = _nodesToPublishAbsFilenameDefault;
                         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("_GW_PNFP")))
                         {
                             Trace("Publishing node configuration file path read from environment.");
-                            NodesToPublishAbsFilename = Environment.GetEnvironmentVariable("_GW_PNFP");
+                            _nodesToPublishAbsFilename = Environment.GetEnvironmentVariable("_GW_PNFP");
                         }
                     }
 
-                    Trace($"Attempting to load nodes file from: {NodesToPublishAbsFilename}");
-                    PublisherConfigFileEntries = JsonConvert.DeserializeObject<List<PublisherConfigFileEntry>>(File.ReadAllText(NodesToPublishAbsFilename));
+                    Trace($"Attempting to load nodes file from: {_nodesToPublishAbsFilename}");
+                    PublisherConfigFileEntries = JsonConvert.DeserializeObject<List<PublisherConfigFileEntry>>(File.ReadAllText(_nodesToPublishAbsFilename));
                     Trace($"Loaded {PublisherConfigFileEntries.Count.ToString()} config file entry/entries.");
 
                     foreach (var publisherConfigFileEntry in PublisherConfigFileEntries)
@@ -523,7 +493,7 @@ namespace OpcPublisher
 
                 // initialize and start IoTHub messaging
                 IotHubCommunication = new IotHubMessaging();
-                if (!IotHubCommunication.Init(_IotHubOwnerConnectionString, _MaxSizeOfIoTHubMessageBytes, _DefaultSendIntervalSeconds))
+                if (! await IotHubCommunication.InitAsync())
                 {
                     return;
                 }
@@ -531,8 +501,8 @@ namespace OpcPublisher
                 // create a list to manage sessions, subscriptions and monitored items.
                 try
                 {
-                    PublishDataSemaphore.Wait();
-                    OpcSessionsSemaphore.Wait();
+                    await PublishDataSemaphore.WaitAsync();
+                    await OpcSessionsListSemaphore.WaitAsync();
                     var uniqueEndpointUrls = PublishConfig.Select(n => n.EndpointUri).Distinct();
                     foreach (var endpointUrl in uniqueEndpointUrls)
                     {
@@ -586,13 +556,13 @@ namespace OpcPublisher
                 }
                 finally
                 {
-                    OpcSessionsSemaphore.Release();
+                    OpcSessionsListSemaphore.Release();
                     PublishDataSemaphore.Release();
                 }
 
                 // kick off the task to maintain all sessions
                 var cts = new CancellationTokenSource();
-                Task.Run( async () => await SessionConnector(cts.Token));
+                Task.Run(() => SessionConnectorAsync(cts.Token));
 
                 // Show notification on session events
                 _publisherServer.CurrentInstance.SessionManager.SessionActivated += ServerEventStatus;
@@ -616,14 +586,14 @@ namespace OpcPublisher
                 _publisherServer.Stop();
 
                 // Clean up Publisher sessions
-                Task.Run(async () => await SessionShutdown()).Wait();
+                SessionShutdownAsync().Wait();
 
                 // shutdown the IoTHub messaging
                 IotHubCommunication.Shutdown();
             }
             catch (Exception e)
             {
-                if (opcTraceInitialized)
+                if (_opcTraceInitialized)
                 {
                     Trace(e, e.StackTrace);
                     e = e.InnerException ?? null;
@@ -653,31 +623,49 @@ namespace OpcPublisher
         /// <summary>
         /// Kicks of the work horse of the publisher regularily for all sessions.
         /// </summary>
-        public static async Task SessionConnector(CancellationToken cancellationtoken)
+        public static async Task SessionConnectorAsync(CancellationToken cancellationtoken)
         {
-            while (true)
+            while (true && !PublisherShutdownInProgress)
             {
                 try
                 {
                     // get tasks for all disconnected sessions and start them
-                    OpcSessionsSemaphore.Wait();
-                    var singleSessionHandlerTaskList = OpcSessions.Select(s => s.ConnectAndMonitor());
-                    OpcSessionsSemaphore.Release();
+                    await OpcSessionsListSemaphore.WaitAsync();
+                    var singleSessionHandlerTaskList = OpcSessions.Select(s => s.ConnectAndMonitorAsync());
+                    OpcSessionsListSemaphore.Release();
                     await Task.WhenAll(singleSessionHandlerTaskList);
                 }
                 catch (Exception e)
                 {
                     Trace(e, $"Failed to connect and monitor a disconnected server. {(e.InnerException != null ? e.InnerException.Message : "")}");
                 }
-                Thread.Sleep(PublisherSessionConnectWaitSec * 1000);
+                await Task.Delay(_publisherSessionConnectWaitSec * 1000);
             }
         }
 
         /// <summary>
-        /// Shutdown all sessions.
+        /// Wait till all sessions are shutdown.
+        /// async tasks.
         /// </summary>
-        public static async Task SessionShutdown()
+        public async static Task SessionShutdownAsync()
         {
+            // Shutdown all sessions.
+            try
+            {
+                await OpcSessionsListSemaphore.WaitAsync();
+                while (OpcSessions.Count > 0)
+                {
+                    OpcSession opcSession = OpcSessions.ElementAt(0);
+                    OpcSessions.RemoveAt(0);
+                    await opcSession.ShutdownAsync();
+                }
+            }
+            finally
+            {
+                OpcSessionsListSemaphore.Release();
+            }
+
+            // Wait and continue after a while.
             uint maxTries = PublisherShutdownWaitPeriod;
             while (true)
             {
@@ -688,11 +676,11 @@ namespace OpcPublisher
                 }
                 if (maxTries-- == 0)
                 {
-                    Trace($"There are stil {sessionCount} sessions alive. Ignore and continue shutdown.");
+                    Trace($"There are still {sessionCount} sessions alive. Ignore and continue shutdown.");
                     return;
                 }
-                Trace($"Publisher is shutting down. Wait {PublisherSessionConnectWaitSec} seconds, since there are stil {sessionCount} sessions alive...");
-                await Task.Delay(PublisherSessionConnectWaitSec * 1000);
+                Trace($"Publisher is shutting down. Wait {_publisherSessionConnectWaitSec} seconds, since there are stil {sessionCount} sessions alive...");
+                await Task.Delay(_publisherSessionConnectWaitSec * 1000);
             }
         }
 
@@ -705,9 +693,9 @@ namespace OpcPublisher
             {
                 Trace($"The Publisher does not trust the server with the certificate subject '{e.Certificate.Subject}'.");
                 Trace("If you want to trust this certificate, please copy it from the directory:");
-                Trace($"{OpcConfiguration.SecurityConfiguration.RejectedCertificateStore.StorePath}/certs");
+                Trace($"{PublisherOpcApplicationConfiguration.SecurityConfiguration.RejectedCertificateStore.StorePath}/certs");
                 Trace("to the directory:");
-                Trace($"{OpcConfiguration.SecurityConfiguration.TrustedPeerCertificates.StorePath}/certs");
+                Trace($"{PublisherOpcApplicationConfiguration.SecurityConfiguration.TrustedPeerCertificates.StorePath}/certs");
             }
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -72,6 +72,7 @@ namespace OpcPublisher
         public static int OpcKeepAliveIntervalInSec = 2;
         public static int OpcSamplingInterval = 1000;
         public static int OpcPublishingInterval = 0;
+        public static bool FetchOpcNodeDisplayName = false;
 
         public static string PublisherServerSecurityPolicy = SecurityPolicies.Basic128Rsa15;
 
@@ -293,6 +294,9 @@ namespace OpcPublisher
 
                     // trust own public cert option
                     { "tm|trustmyself=", $"the publisher certificate is put into the trusted certificate store automatically.\nDefault: {TrustMyself}", (bool b) => TrustMyself = b },
+
+                    // read the display name of the nodes to publish from the server and publish them instead of the node id
+                    { "fd|fetchdisplayname=", $"enable to read the display name of a published node from the server. this will increase the runtime.\nDefault: {FetchOpcNodeDisplayName}", (bool b) => FetchOpcNodeDisplayName = b },
 
                     // own cert store options
                     { "at|appcertstoretype=", $"the own application cert store type. \n(allowed values: Directory, X509Store)\nDefault: '{OpcOwnCertStoreType}'", (string s) => {

--- a/src/PublisherNodeManager.cs
+++ b/src/PublisherNodeManager.cs
@@ -100,33 +100,22 @@ namespace OpcPublisher
 
                 try
                 {
-                    #region DataAccess_DataItem
                     FolderState dataFolder = CreateFolder(root, "Data", "Data");
 
                     const string connectionStringItemName = "ConnectionString";
                     DataItemState item = CreateDataItemVariable(dataFolder, connectionStringItemName, connectionStringItemName, BuiltInType.String, ValueRanks.Scalar, AccessLevels.CurrentWrite);
                     item.Value = String.Empty;
-                    #endregion
 
-                    #region Methods
                     FolderState methodsFolder = CreateFolder(root, "Methods", "Methods");
 
-                    #region PublishNode Method
                     MethodState publishNodeMethod = CreateMethod(methodsFolder, "PublishNode", "PublishNode");
                     SetPublishNodeMethodProperties(ref publishNodeMethod);
-                    #endregion
 
-                    #region UnpublishNode Method
                     MethodState unpublishNodeMethod = CreateMethod(methodsFolder, "UnpublishNode", "UnpublishNode");
                     SetUnpublishNodeMethodProperties(ref unpublishNodeMethod);
-                    #endregion
 
-                    #region GetListOfPublishedNodes Method
                     MethodState getListOfPublishedNodesMethod = CreateMethod(methodsFolder, "GetListOfPublishedNodes", "GetListOfPublishedNodes");
                     SetGetListOfPublishedNodesMethodProperties(ref getListOfPublishedNodesMethod);
-                    #endregion
-
-                    #endregion Methods
                 }
                 catch (Exception e)
                 {
@@ -457,7 +446,7 @@ namespace OpcPublisher
             // find/create a session to the endpoint URL and start monitoring the node.
             try
             {
-                if (PublisherShutdownInProgress)
+                if (ShutdownTokenSource.IsCancellationRequested)
                 {
                     return ServiceResult.Create(StatusCodes.BadUnexpectedError, $"Publisher shutdown in progress.");
                 }
@@ -551,7 +540,7 @@ namespace OpcPublisher
             // find the session and stop monitoring the node.
             try
             {
-                if (PublisherShutdownInProgress)
+                if (ShutdownTokenSource.IsCancellationRequested)
                 {
                     return ServiceResult.Create(StatusCodes.BadUnexpectedError, $"Publisher shutdown in progress.");
                 }

--- a/src/SecureIoTHubToken.cs
+++ b/src/SecureIoTHubToken.cs
@@ -25,7 +25,6 @@ namespace IoTHubCredentialTools
         /// <summary>
         /// Validates the cert and extracts the token from the cert.
         /// </summary>
-        /// <returns></returns>
         private static string CheckForToken(X509Certificate2 cert, string name)
         {
             if ((cert.SubjectName.Decode(X500DistinguishedNameFlags.None | X500DistinguishedNameFlags.DoNotUseQuotes).Equals("CN=" + name, StringComparison.OrdinalIgnoreCase)) &&
@@ -55,7 +54,6 @@ namespace IoTHubCredentialTools
         /// <summary>
         /// Returns the token from the cert in the given cert store.
         /// </summary>
-        /// <returns></returns>
         public async static Task<string> ReadAsync(string name, string storeType, string storePath)
         {
             string token = null;
@@ -200,12 +198,12 @@ namespace IoTHubCredentialTools
                                 {
                                     if (cert.SubjectName.Decode(X500DistinguishedNameFlags.None | X500DistinguishedNameFlags.DoNotUseQuotes).Equals("CN=" + name, StringComparison.OrdinalIgnoreCase))
                                     {
-                                        store.Delete(cert.Thumbprint);
+                                        await store.Delete(cert.Thumbprint);
                                     }
                                 }
 
                                 // add new one
-                                store.Add(certificate);
+                                await store.Add(certificate);
                             }
                             break;
                         }

--- a/src/TraceWorkaround.cs
+++ b/src/TraceWorkaround.cs
@@ -10,14 +10,13 @@ namespace OpcPublisher.Workarounds
     /// </summary>
     public static class TraceWorkaround
     {
-        private static int _opcStackTraceMask;
-        private static bool _verboseConsole;
-
-        public static void Init(int opcStackTraceMask, bool verboseConsole)
+        public static bool VerboseConsole
         {
-            _opcStackTraceMask = opcStackTraceMask;
-            _verboseConsole = verboseConsole;
+            get => _verboseConsole;
+            set => _verboseConsole = value;
         }
+        private static bool _verboseConsole = false;
+
         /// <summary>
         /// Trace message helper
         /// </summary>
@@ -42,7 +41,7 @@ namespace OpcPublisher.Workarounds
         public static void Trace(int traceMask, string format, params object[] args)
         {
             Utils.Trace(traceMask, format, args);
-            if (_verboseConsole && (_opcStackTraceMask & traceMask) != 0)
+            if (_verboseConsole && (OpcStackConfiguration.OpcStackTraceMask & traceMask) != 0)
             {
                 WriteLine(DateTime.Now.ToString() + ": " + format, args);
             }


### PR DESCRIPTION
This PR has changes to:
- Make the fetching of the OPC Node display name optional, by default it is disabled to improve startup performance. Fetching the display name could be enabled via command line option.
- Publisher is now a .NET Core 2.0 application
- The latest OPC stack nuget package 0.4.5 is used