### PR TITLE
Add IoT Edge support, add telemetry configuration, add support for unsecured server connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,40 @@ There is a prebuilt container available on DockerHub. To start it, just do:
 
     docker run microsoft/iot-edge-opc-publisher <applicationname> [<iothubconnectionstring>] [options]
 
+## Using it as a module in Azure IoT Edge
+[Azure IoT Edge](https://docs.microsoft.com/en-us/azure/iot-edge) is now in public preview and OpcPublisher is ready to be used as a module to run in IoT Edge.
+We recommend to take a look on the information available on the beforementioned link and use then the information provided here. You need to install the IoT Edge as
+explained in the Quickstart guides and create an IoTHub to be able to configure the modules to run on IoT Edge.
+
+To add publisher as module to your IoT Edge deployment, you go to the Azure portal and navigate to your IoTHub and:
+* Go to IoT Edge (preview) and select your IoT Edge device.
+* Select `Set Modules`.
+* Select `Add IoT Edge Module`.
+* In the `Name` field, enter `iot-edge-opc-publisher`.
+In the `Image URI` field, enter `microsoft/iot-edge-opc-publisher:latest`
+* Paste the following into the `Container Create Options` field:
+
+        {
+            "Hostname": "publisher",
+            "Cmd": [
+                "dotnet", "/build/out/OpcPublisher.dll", "publisher", "--pf", "/docker/publishednodes.json", "--lf", "/docker/publisher.log.txt", "--si", "1", "--ms", "0", "--di", "5", "--fd", "true", "--tm", "true", "--as", "true", "--vc", "true", "--ih", "Mqtt_Tcp_Only"
+            ],
+            "HostConfig": {
+                    "Binds": [
+                        "//d/docker/docker:/docker"
+                    ]
+            }
+        }
+
+* Adjust the command line parameters in `Cmd` as needed
+* Adjust the `Binds` source, which is set in the example to `//d/docker/docker`, which means that the publishednodes.json and the publisher.log.txt are put into
+  folder d:\docker\docker on the Windows host IoT Edge is running (Note: you need to apply the the appropriate Settings to allow Docker for Windows accessing the drives.)
+* Update your publishednodes.json file as needed.
+* Leave the other settings unchanged and select `Save`.
+* Back in the `Set Modules` page, select `Next` twice and then `Submit`
+
+
+
 ## Important when using a container
 
 ### Access to the Publisher OPC UA server

--- a/README.md
+++ b/README.md
@@ -555,9 +555,19 @@ In the `Image URI` field, enter `microsoft/iot-edge-opc-publisher:latest`
 * Adjust the command line parameters in `Cmd` as needed
 * Adjust the `Binds` source, which is set in the example to `//d/docker/docker`, which means that the publishednodes.json and the publisher.log.txt are put into
   folder d:\docker\docker on the Windows host IoT Edge is running (Note: you need to apply the the appropriate Settings to allow Docker for Windows accessing the drives.)
-* Update your publishednodes.json file as needed.
 * Leave the other settings unchanged and select `Save`.
-* Back in the `Set Modules` page, select `Next` twice and then `Submit`
+* Back in the `Set Modules` page, select `Next`
+* Add the following route in the `Specify Routes` page:
+
+        {
+           "routes":{
+              "upstream":"FROM /* INTO $upstream"
+           }
+        }
+
+* Select `Next`
+* Update your publishednodes.json file on your system IoT Edge is running as needed.
+* Select `Submit` to send your configuration down to IoT Edge
 
 
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The syntax of the configuration file is as follows:
         //      "DisplayName": "CurrentTime",
         //      "Value": {
         //          "Value": "10.11.2017 14:03:17",
-        //          "SourceTimestamp": "2017-11-10 14:03:17Z"
+        //          "SourceTimestamp": "2017-11-10T14:03:17Z"
         //      }
         //  }
 
@@ -202,7 +202,7 @@ The syntax of the configuration file is as follows:
                     // members won't be nested:
                     //      "DisplayName": "CurrentTime",
                     //      "Value": "10.11.2017 14:03:17",
-                    //      "SourceTimestamp": "2017-11-10 14:03:17Z"
+                    //      "SourceTimestamp": "2017-11-10T14:03:17Z"
                     // The 'Flat' property can only be used for the 'MonitoredItem' and 'Value'
                     // objects of the 'Defaults' object and will be used for all
                     // messages sent by publisher.
@@ -216,10 +216,11 @@ The syntax of the configuration file is as follows:
                         "Publish": true,
                         "Name": "SourceTimestamp"
                     },
-                    // StatusCode is the 32 bit OPC UA status code formatted as hexadezimal number.
+                    // 'StatusCode' is the 32 bit OPC UA status code
                     "StatusCode": {
                         "Publish": false,
                         "Name": "StatusCode"
+                        // 'Pattern' is ignored for the 'StatusCode' value
                     },
                     // 'Status' is the symbolic name of 'StatusCode'
                     "Status": {

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The syntax of the configuration file is as follows:
 
 # Configuring the telemetry published to IoTHub
 When OpcPublisher gets notified about a value change in one of the configured published nodes, it generates a JSON formatted message, which is sent to IoTHub.
-The content of this JSON formatted message could be configured via a configuration file. If no configuration file is specified via the `--tc` option a default configuration is used,
+The content of this JSON formatted message can be configured via a configuration file. If no configuration file is specified via the `--tc` option a default configuration is used,
 which is compatible with the [Connected factory Preconfigured Solution](https://github.com/Azure/azure-iot-connected-factory).
 
 The data which is ingested is taken from three sources:
@@ -154,7 +154,7 @@ The syntax of the configuration file is as follows:
                     // Name allows you to use a shorter string as property name in the JSON message
                     // sent by publisher. By default the property name is unchanged and will be
                     // here 'EndpointUrl'.
-                    // The 'Name' property could only be set in the 'Defaults' object to ensure
+                    // The 'Name' property can only be set in the 'Defaults' object to ensure
                     // all messages from publisher sent to IoTHub have a similar layout.
                     "Name": "EndpointUrl"
 
@@ -180,7 +180,7 @@ The syntax of the configuration file is as follows:
                     //          "ApplicationUri": "urn:myopcserver",
                     //          "DisplayName": "CurrentTime",
                     //      }
-                    // The 'Flat' property could only be used in the 'MonitoredItem' and
+                    // The 'Flat' property can only be used in the 'MonitoredItem' and
                     // 'Value' objects of the 'Defaults' object and will be used
                     // for all JSON messages sent by publisher.
                     "Flat": true,
@@ -203,7 +203,7 @@ The syntax of the configuration file is as follows:
                     //      "DisplayName": "CurrentTime",
                     //      "Value": "10.11.2017 14:03:17",
                     //      "SourceTimestamp": "2017-11-10 14:03:17Z"
-                    // The 'Flat' property could only be used for the 'MonitoredItem' and 'Value'
+                    // The 'Flat' property can only be used for the 'MonitoredItem' and 'Value'
                     // objects of the 'Defaults' object and will be used for all
                     // messages sent by publisher.
                     "Flat": false,
@@ -234,7 +234,7 @@ The syntax of the configuration file is as follows:
             // or the defaults used by publisher.
             // It is not allowed to specify 'Name' and 'Flat' properties in this object.
             "EndpointSpecific": [
-                // The following shows how a endpoint specific configuration could look like:
+                // The following shows how a endpoint specific configuration can look like:
                 {
                     // 'ForEndpointUrl' allows to configure for which OPC UA server this
                     // object applies and is a required property for all objects in the
@@ -335,8 +335,8 @@ The complete usage of the application can be shown using the `--help` command li
                                        Default: 10
               --mq, --monitoreditemqueuecapacity=VALUE
                                      specify how many notifications of monitored items
-                                       could be stored in the internal queue, if the
-                                       data could not be sent quick enough to IoTHub
+                                       can be stored in the internal queue, if the
+                                       data can not be sent quick enough to IoTHub
                                        Min: 1024
                                        Default: 8192
               --di, --diagnosticsinterval=VALUE
@@ -348,7 +348,7 @@ The complete usage of the application can be shown using the `--help` command li
                                      the output of publisher is shown on the console.
                                        Default: False
               --ns, --noshutdown=VALUE
-                                     publisher could not be stopped by pressing a key
+                                     publisher can not be stopped by pressing a key
                                        on the console, but will run forever.
                                        Default: False
               --ih, --iothubprotocol=VALUE
@@ -616,7 +616,7 @@ Since both are interdependent and both depend on the configuration of how many n
 do meet your requirements.
 
 The `--mq` parameter controls the upper bound of the capacity of the internal queue, which buffers all notifications if a value of an OPC node changes. If Publisher is not able to send messages to IoTHub fast enough,
-then this queue buffers those notifications. The parameter sets the number of notifications which could be buffered. If you seen the number of items in this queue increasing in your test runs, you need to:
+then this queue buffers those notifications. The parameter sets the number of notifications which can be buffered. If you seen the number of items in this queue increasing in your test runs, you need to:
 * decrease the IoTHub send interval (`--si`)
 * increase the IoTHub message size (`--ms`)
 otherwise you will loose the data values of those OPC node changes. The `--mq` parameter at the same time allows to prevent controlling the upper bound of the memory resources used by Publisher.
@@ -628,7 +628,7 @@ uses the maximal possible IoTHub message size of 256 kB to batch data.
 The `--ms` parameter allows you to enable batching of messages sent to IoTHub. Depending on the protocol you are using, the overhead to send a message to IoTHub is high compared to the actual time of sending the payload.
 If your scenario allows latency for the data ingested, you should configure Publisher to use the maximal message size of 256 kB.
 
-Before you use Publisher in production scenarios, you need to test the performance and memory under production conditions. You could use the `--di` commandline parameter to specify a interval in seconds,
+Before you use Publisher in production scenarios, you need to test the performance and memory under production conditions. You can use the `--di` commandline parameter to specify a interval in seconds,
 which will trigger the output of diagnostic information at this interval.
 
 ### Test measurements
@@ -765,7 +765,7 @@ lost OPC node value updates (`monitored item notifications enqueue failure: 4462
         ==========================================================================
 
 This configuration batches as much OPC node value udpates as possible. The maximum IoTHub message size is 256 kB, which is configured here. There is no send interval requested, which makes the time when data is ingested
-completely controlled by the data itself. This configuration has the least probability of loosing any OPC node values and could be used for publishing a high number of nodes.
+completely controlled by the data itself. This configuration has the least probability of loosing any OPC node values and can be used for publishing a high number of nodes.
 When using this configuration you need to ensure, that your scenario does not have conditions where high latency is introduced (because the message size of 256 kB is not reached).
 
 # Debugging the Application
@@ -828,7 +828,7 @@ Build your project and publish it to a directory of your choice.
 
 Use a tool like WinSCP to copy over the published files to the container into the directory `/root/publisher` (this can be also a different directory, but needs to be in sync with the `cdw` property of launch.json.
 
-Now you could start debugging with the following command in Visual Studio's Command Window (View->Other Windows->Command Window):
+Now you can start debugging with the following command in Visual Studio's Command Window (View->Other Windows->Command Window):
 DebugAdapterHost.Launch /LaunchJson:"<path-to-the-launch.json-file-you-saved>"
 
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,9 @@ The telemetry which is put into the JSON formatted message is a selection of imp
 
 The syntax of the configuration file is as follows:
 
-        // The configuration file consists of two objects:
-        // 1) The 'Defaults' object, which defines default settings for the telemetry
-        //    configuration as well as a few control settings.
-        // 2) An array 'EndpointSpecific' of endpoint specific configuration settings
+        // The configuration settings file consists of two objects:
+        // 1) The 'Defaults' object, which defines defaults for the telemetry configuration
+        // 2) An array 'EndpointSpecific' of endpoint specific configuration
         // Both objects are optional and if they are not specified, then publisher uses
         // its internal default configuration, which generates telemetry messages compatible
         // with the Microsoft Connected factory Preconfigured Solution (https://github.com/Azure/azure-iot-connected-factory).
@@ -119,7 +118,7 @@ The syntax of the configuration file is as follows:
         //      }
         //  }
 
-        // The settings of 'Defaults' in the sample below, are similar to what publisher is
+        // The 'Defaults' object in the sample below, are similar to what publisher is
         // using as its internal default telemetry configuration.
         {
             "Defaults": {
@@ -181,8 +180,8 @@ The syntax of the configuration file is as follows:
                     //          "ApplicationUri": "urn:myopcserver",
                     //          "DisplayName": "CurrentTime",
                     //      }
-                    // The 'Flat' property could only be used for the 'MonitoredItem' and
-                    // 'Value' configuratíon settings of the 'Defaults' objet and will be used
+                    // The 'Flat' property could only be used in the 'MonitoredItem' and
+                    // 'Value' objects of the 'Defaults' object and will be used
                     // for all JSON messages sent by publisher.
                     "Flat": true,
 
@@ -205,7 +204,7 @@ The syntax of the configuration file is as follows:
                     //      "Value": "10.11.2017 14:03:17",
                     //      "SourceTimestamp": "2017-11-10 14:03:17Z"
                     // The 'Flat' property could only be used for the 'MonitoredItem' and 'Value'
-                    // objects of the 'Defaults' object and will be used for all JSON
+                    // objects of the 'Defaults' object and will be used for all
                     // messages sent by publisher.
                     "Flat": false,
 
@@ -230,9 +229,9 @@ The syntax of the configuration file is as follows:
                 }
             },
 
-            // The next object allows to configure 'Publish' and 'Pattern' settings for specific
-            // endpoint URLs. Those will overwrite the settings specified in the 'Defaults' object
-            // or the default settings used by publisher.
+            // The next object allows to configure 'Publish' and 'Pattern' for specific
+            // endpoint URLs. Those will overwrite the ones specified in the 'Defaults' object
+            // or the defaults used by publisher.
             // It is not allowed to specify 'Name' and 'Flat' properties in this object.
             "EndpointSpecific": [
                 // The following shows how a endpoint specific configuration could look like:

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The syntax of the configuration file is as follows:
                     //      "Value": "10.11.2017 14:03:17",
                     //      "SourceTimestamp": "2017-11-10 14:03:17Z"
                     // The 'Flat' property could only be used for the 'MonitoredItem' and 'Value'
-                    // configuratíon settings of the 'Defaults' objet and will be used for all JSON
+                    // objects of the 'Defaults' object and will be used for all JSON
                     // messages sent by publisher.
                     "Flat": false,
 
@@ -271,7 +271,7 @@ The syntax of the configuration file is as follows:
                     "Value": {
                         "Value": {
                             // The value of the node is important for us, everything else we
-                            //are not interested in to keep the data ingest as small as possible.
+                            // are not interested in to keep the data ingest as small as possible.
                             "Publish": true
                         },
                         "SourceTimestamp": {

--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -404,7 +404,7 @@ namespace OpcPublisher
 
                 // process Value object properties
                 if (!string.IsNullOrEmpty(messageData.Value) || !string.IsNullOrEmpty(messageData.SourceTimestamp) ||
-                   !string.IsNullOrEmpty(messageData.StatusCode) || !string.IsNullOrEmpty(messageData.Status))
+                   messageData.StatusCode != null || !string.IsNullOrEmpty(messageData.Status))
                 {
                     if (!(bool)telemetryConfiguration.Value.Flat)
                     {
@@ -434,7 +434,7 @@ namespace OpcPublisher
                     }
 
                     // process StatusCode
-                    if (!string.IsNullOrEmpty(messageData.StatusCode))
+                    if (messageData.StatusCode != null)
                     {
                         await _jsonWriter.WritePropertyNameAsync(telemetryConfiguration.Value.StatusCode.Name);
                         await _jsonWriter.WriteValueAsync(messageData.StatusCode);
@@ -527,7 +527,7 @@ namespace OpcPublisher
                             // sanity check that the user has set a large enough IoTHub messages size
                             if ((_iotHubMessageSize > 0 && jsonMessageSize > _iotHubMessageSize ) || (_iotHubMessageSize == 0 && jsonMessageSize > iotHubMessageBufferSize))
                             {
-                                Trace(Utils.TraceMasks.Error, $"There is a telemetry message (size: {jsonMessageSize}), which will not fit into an IoTHub message (max size: {_iotHubMessageSize}].");
+                                Trace(Utils.TraceMasks.Error, $"There is a telemetry message (size: {jsonMessageSize}), which will not fit into an IoTHub message (max size: {iotHubMessageBufferSize}].");
                                 Trace(Utils.TraceMasks.Error, $"Please check your IoTHub message size settings. The telemetry message will be discarded silently. Sorry:(");
                                 _tooLargeCount++;
                                 continue;

--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -10,7 +10,6 @@ namespace OpcPublisher
     using Microsoft.Azure.Devices.Client;
     using Opc.Ua;
     using System;
-    using System.Diagnostics;
     using System.IO;
     using static Opc.Ua.CertificateStoreType;
     using static OpcPublisher.Diagnostics;
@@ -366,8 +365,8 @@ namespace OpcPublisher
                         {
                             Microsoft.Azure.Devices.Client.Message encodedIotHubMessage = null;
 
-                            // if we reached the send interval, but have nothing to send, we continue
-                            if (!gotItem && iotHubMessage.Position == 0)
+                            // if we reached the send interval, but have nothing to send (only the opening square bracket is there), we continue
+                            if (!gotItem && iotHubMessage.Position == 1)
                             {
                                 nextSendTime += TimeSpan.FromSeconds(_defaultSendIntervalSeconds);
                                 iotHubMessage.Position = 0;

--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -15,13 +15,11 @@ namespace OpcPublisher
     using System.IO;
     using System.Runtime.InteropServices;
     using System.Security.Cryptography.X509Certificates;
-    using static Opc.Ua.CertificateStoreType;
     using static OpcPublisher.Diagnostics;
     using static OpcPublisher.OpcMonitoredItem;
     using static OpcPublisher.PublisherTelemetryConfiguration;
     using static OpcPublisher.Workarounds.TraceWorkaround;
     using static OpcStackConfiguration;
-    using static Program;
 
     /// <summary>
     /// Class to handle all IoTHub communication.
@@ -246,7 +244,7 @@ namespace OpcPublisher
                     // During dev you might want to bypass the cert verification. It is highly recommended to verify certs systematically in production
                     if (bypassCertVerification)
                     {
-                        Trace($"ATTENTION: You are bypassing the EdgeHub security cert verfication. Please ensure the was by intent.");
+                        Trace($"ATTENTION: You are bypassing the EdgeHub security cert verfication. Please ensure this was intentional.");
                         mqttSettings.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
                     }
                     ITransportSettings[] transportSettings = { mqttSettings };
@@ -418,7 +416,14 @@ namespace OpcPublisher
                     if (!string.IsNullOrEmpty(messageData.Value))
                     {
                         await _jsonWriter.WritePropertyNameAsync(telemetryConfiguration.Value.Value.Name);
-                        await _jsonWriter.WriteValueAsync(messageData.Value);
+                        if (messageData.PreserveValueQuotes)
+                        {
+                            await _jsonWriter.WriteValueAsync(messageData.Value);
+                        }
+                        else
+                        {
+                            await _jsonWriter.WriteRawValueAsync(messageData.Value);
+                        }
                     }
 
                     // process SourceTimestamp

--- a/src/OpcPublisher.csproj
+++ b/src/OpcPublisher.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.5.1" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.5.0-preview-001" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.6.0-preview-001" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="0.4.5" />
   </ItemGroup>

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -150,7 +150,7 @@ namespace OpcPublisher
             public string DisplayName;
             public string Value;
             public string SourceTimestamp;
-            public string StatusCode;
+            public uint? StatusCode;
             public string Status;
             public bool PreserveValueQuotes;
 
@@ -193,9 +193,12 @@ namespace OpcPublisher
                 {
                     SourceTimestamp = telemetryConfiguration.Value.SourceTimestamp.PatternMatch(SourceTimestamp);
                 }
-                if (telemetryConfiguration.Value.StatusCode.Publish == true)
+                if (telemetryConfiguration.Value.StatusCode.Publish == true && StatusCode != null)
                 {
-                    StatusCode = telemetryConfiguration.Value.StatusCode.PatternMatch(StatusCode);
+                    if (!string.IsNullOrEmpty(telemetryConfiguration.Value.StatusCode.Pattern))
+                    {
+                        Trace($"'Pattern' settngs for StatusCode are ignored.");
+                    }
                 }
                 if (telemetryConfiguration.Value.Status.Publish == true)
                 {
@@ -249,13 +252,13 @@ namespace OpcPublisher
                 }
                 if (telemetryConfiguration.Value.SourceTimestamp.Publish == true && value.SourceTimestamp != null)
                 {
-                    // use the SourceTimestamp as reported in the notification event argument in univeral sortable format
-                    messageData.SourceTimestamp = value.SourceTimestamp.ToString();
+                    // use the SourceTimestamp as reported in the notification event argument in ISO8601 format
+                    messageData.SourceTimestamp = value.SourceTimestamp.ToString("o");
                 }
                 if (telemetryConfiguration.Value.StatusCode.Publish == true && value.StatusCode != null)
                 {
                     // use the StatusCode as reported in the notification event argument
-                    messageData.StatusCode = value.StatusCode.Code.ToString("X");
+                    messageData.StatusCode = value.StatusCode.Code;
                 }
                 if (telemetryConfiguration.Value.Status.Publish == true && value.StatusCode != null)
                 {
@@ -278,7 +281,7 @@ namespace OpcPublisher
                     messageData.PreserveValueQuotes = true;
                     if (markerStart >= 0)
                     {
-                        // we either have a value in quotes of just a value
+                        // we either have a value in quotes or just a value
                         int valueLength;
                         int valueStart = marker.Length;
                         if (valueString.IndexOf("\"", valueStart) >= 0)

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -256,8 +256,11 @@ namespace OpcPublisher
                     // and get it
                     string marker = "{\"Value\":{\"Value\":\"";
                     int markerStart = valueString.IndexOf(marker);
-                    int valueLength = valueString.Length - marker.Length - 3;
-                    messageData.Value = valueString.Substring(markerStart + marker.Length, valueLength);
+                    if (markerStart >= 0 && valueString.Length - marker.Length > 3)
+                    {
+                        int valueLength = valueString.Length - marker.Length - 3;
+                        messageData.Value = valueString.Substring(markerStart + marker.Length, valueLength);
+                    }
                     value.StatusCode = savedStatusCode;
                 }
                 if (telemetryConfiguration.Value.SourceTimestamp.Publish == true && value.SourceTimestamp != null)

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -426,9 +426,43 @@ namespace OpcPublisher
 
                 // serialize the object and patch the value name in case we are no flat
                 string json = JsonConvert.SerializeObject(messageData);
+
+                // update property names
                 if (valueIsFlat == false)
                 {
                     json = json.Replace(MessageData.ValueInfoReplacementTag, "Value");
+                }
+                if (telemetryConfiguration.MonitoredItem.ApplicationUri.Publish && !string.IsNullOrEmpty(telemetryConfiguration.MonitoredItem.ApplicationUri.Name))
+                {
+                    json = json.Replace($"\"{ApplicationUriKeyDefault}\":", $"\"{telemetryConfiguration.MonitoredItem.ApplicationUri.Name}\":");
+                }
+                if (telemetryConfiguration.MonitoredItem.DisplayName.Publish && !string.IsNullOrEmpty(telemetryConfiguration.MonitoredItem.DisplayName.Name))
+                {
+                    json = json.Replace($"\"{DisplayNameKeyDefault}\":", $"\"{telemetryConfiguration.MonitoredItem.DisplayName.Name}\":");
+                }
+                if (telemetryConfiguration.Value.Value.Publish && !string.IsNullOrEmpty(telemetryConfiguration.Value.Value.Name))
+                {
+                    json = json.Replace($"\"{ValueKeyDefault}\":", $"\"{telemetryConfiguration.Value.Value.Name}\":");
+                }
+                if (telemetryConfiguration.Value.SourceTimestamp.Publish && !string.IsNullOrEmpty(telemetryConfiguration.Value.SourceTimestamp.Name))
+                {
+                    json = json.Replace($"\"{SourceTimestampKeyDefault}\":", $"\"{telemetryConfiguration.Value.SourceTimestamp.Name}\":");
+                }
+                if (telemetryConfiguration.Value.StatusCode.Publish && !string.IsNullOrEmpty(telemetryConfiguration.Value.StatusCode.Name))
+                {
+                    json = json.Replace($"\"{StatusCodeKeyDefault}\":", $"\"{telemetryConfiguration.Value.StatusCode.Name}\":");
+                }
+                if (telemetryConfiguration.Value.Status.Publish && !string.IsNullOrEmpty(telemetryConfiguration.Value.Status.Name))
+                {
+                    json = json.Replace($"\"{StatusKeyDefault}\":", $"\"{telemetryConfiguration.Value.Status.Name}\":");
+                }
+                if (telemetryConfiguration.EndpointUrl.Publish && !string.IsNullOrEmpty(telemetryConfiguration.EndpointUrl.Name))
+                {
+                    json = json.Replace($"\"{EndpointUrlKeyDefault}\":", $"\"{telemetryConfiguration.EndpointUrl.Name}\":");
+                }
+                if (telemetryConfiguration.NodeId.Publish && !string.IsNullOrEmpty(telemetryConfiguration.NodeId.Name))
+                {
+                    json = json.Replace($"\"{NodeIdDefault}\":", $"\"{telemetryConfiguration.NodeId.Name}\":");
                 }
 
                 // add message to fifo send queue

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -292,7 +292,7 @@ namespace OpcPublisher
                 }
 
                 // process MonitoredItem DisplayName property
-                if (telemetryConfiguration.MonitoredItem.DisplayName.Publish == true)
+                if (telemetryConfiguration.MonitoredItem.DisplayName.Publish == true && monitoredItem != null && monitoredItem.DisplayName != null)
                 {
                     // use the DisplayName as reported in the MonitoredItem
                     telemetryValue = monitoredItem.DisplayName;
@@ -324,7 +324,7 @@ namespace OpcPublisher
                 }
 
                 // process notification Value Value property
-                if (telemetryConfiguration.Value.Value.Publish == true)
+                if (telemetryConfiguration.Value.Value.Publish == true && value.Value != null)
                 {
                     // use the Value as reported in the notification event argument
                     telemetryValue = value.Value.ToString();
@@ -345,7 +345,7 @@ namespace OpcPublisher
                 }
 
                 // process notification Value SourceTimestamp property
-                if (telemetryConfiguration.Value.SourceTimestamp.Publish == true)
+                if (telemetryConfiguration.Value.SourceTimestamp.Publish == true && value.SourceTimestamp != null)
                 {
                     // use the SourceTimestamp as reported in the notification event argument in univeral sortable format
                     telemetryValue = value.SourceTimestamp.ToString("u");
@@ -366,9 +366,9 @@ namespace OpcPublisher
                 }
 
                 // process notification Value StatusCode property
-                if (telemetryConfiguration.Value.StatusCode.Publish == true)
+                if (telemetryConfiguration.Value.StatusCode.Publish == true && value.StatusCode != null)
                 {
-                    // use the SourceTimestamp as reported in the notification event argument in univeral sortable format
+                    // use the StatusCode as reported in the notification event argument
                     telemetryValue = value.StatusCode.Code.ToString("X");
                     if (!string.IsNullOrEmpty(telemetryConfiguration.Value.StatusCode.Pattern))
                     {
@@ -388,9 +388,9 @@ namespace OpcPublisher
 
 
                 // process notification Value StatusCode property as symbolic name
-                if (telemetryConfiguration.Value.Status.Publish == true)
+                if (telemetryConfiguration.Value.Status.Publish == true && value.StatusCode != null)
                 {
-                    // use the SourceTimestamp as reported in the notification event argument in univeral sortable format
+                    // use the StatusCode as reported in the notification event argument to lookup the symbolic name
                     telemetryValue = StatusCode.LookupSymbolicId(value.StatusCode.Code);
                     if (!string.IsNullOrEmpty(telemetryConfiguration.Value.Status.Pattern))
                     {

--- a/src/OpcStackConfiguration.cs
+++ b/src/OpcStackConfiguration.cs
@@ -86,11 +86,15 @@ namespace OpcPublisher
             set => _opcKeepAliveIntervalInSec = value;
         }
 
+        public const int OpcSamplingIntervalDefault = 1000;
+
         public static int OpcSamplingInterval
         {
             get => _opcSamplingInterval;
             set => _opcSamplingInterval = value;
         }
+
+        public const int OpcPublishingIntervalDefault = 0;
 
         public static int OpcPublishingInterval
         {
@@ -409,16 +413,16 @@ namespace OpcPublisher
         private static uint _opcSessionCreationBackoffMax = 5;
         private static uint _opcKeepAliveDisconnectThreshold = 5;
         private static int _opcKeepAliveIntervalInSec = 2;
-        private static int _opcSamplingInterval = 1000;
-        private static int _opcPublishingInterval = 0;
+        private static int _opcSamplingInterval = OpcSamplingIntervalDefault;
+        private static int _opcPublishingInterval = OpcPublishingIntervalDefault;
         private static string _publisherServerSecurityPolicy = SecurityPolicies.Basic128Rsa15;
         private static string _opcOwnCertStoreType = X509Store;
         private static string _opcOwnCertStorePath = OpcOwnCertX509StorePathDefault;
-        private static string _opcTrustedCertStoreType = CertificateStoreType.Directory;
+        private static string _opcTrustedCertStoreType = Directory;
         private static string _opcTrustedCertStorePath = null;
-        private static string _opcRejectedCertStoreType = CertificateStoreType.Directory;
+        private static string _opcRejectedCertStoreType = Directory;
         private static string _opcRejectedCertStorePath = OpcRejectedCertDirectoryStorePathDefault;
-        private static string _opcIssuerCertStoreType = CertificateStoreType.Directory;
+        private static string _opcIssuerCertStoreType = Directory;
         private static string _opcIssuerCertStorePath = OpcIssuerCertDirectoryStorePathDefault;
         private static int _ldsRegistrationInterval = 0;
         private static ApplicationConfiguration _configuration;

--- a/src/OpcStackConfiguration.cs
+++ b/src/OpcStackConfiguration.cs
@@ -390,6 +390,7 @@ namespace OpcPublisher
             Trace($"Log file is: {Utils.GetAbsoluteFilePath(_configuration.TraceConfiguration.OutputFilePath, true, false, false, true)}");
             Trace($"opcstacktracemask set to: 0x{_opcStackTraceMask:X} ({_opcStackTraceMask})");
 
+            // add deafult client configuration
             _configuration.ClientConfiguration = new ClientConfiguration();
 
             // validate the configuration now

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -432,11 +432,19 @@ namespace OpcPublisher
                 // stop on user request
                 WriteLine("");
                 WriteLine("");
-                WriteLine("Publisher is running. Press ENTER to quit.");
+                WriteLine("Publisher is running. Press any key to quit.");
+                try
+                {
+                    ReadKey(true);
+                }
+                catch
+                {
+                    // wait forever if there is no console
+                    await Task.Delay(Timeout.Infinite);
+                }
                 WriteLine("");
                 WriteLine("");
-                ReadLine();
-               ShutdownTokenSource.Cancel();
+                ShutdownTokenSource.Cancel();
                 WriteLine("Publisher is shutting down...");
 
                 // Wait for session connector completion

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -86,7 +86,7 @@ namespace OpcPublisher
                             }
                         }
                     },
-                    { "mq|monitoreditemqueuecapacity=", $"specify how many notifications of monitored items could be stored in the internal queue, if the data could not be sent quick enough to IoTHub\nMin: 1024\nDefault: {MonitoredItemsQueueCapacity}", (int i) => {
+                    { "mq|monitoreditemqueuecapacity=", $"specify how many notifications of monitored items can be stored in the internal queue, if the data can not be sent quick enough to IoTHub\nMin: 1024\nDefault: {MonitoredItemsQueueCapacity}", (int i) => {
                             if (i >= 1024)
                             {
                                 MonitoredItemsQueueCapacity = i;
@@ -101,7 +101,7 @@ namespace OpcPublisher
 
                     { "vc|verboseconsole=", $"the output of publisher is shown on the console.\nDefault: {VerboseConsole}", (bool b) => VerboseConsole = b },
 
-                    { "ns|noshutdown=", $"publisher could not be stopped by pressing a key on the console, but will run forever.\nDefault: {_noShutdown}", (bool b) => _noShutdown = b },
+                    { "ns|noshutdown=", $"publisher can not be stopped by pressing a key on the console, but will run forever.\nDefault: {_noShutdown}", (bool b) => _noShutdown = b },
                     
                     // IoTHub specific options
                     { "ih|iothubprotocol=", $"the protocol to use for communication with Azure IoTHub (allowed values: {string.Join(", ", Enum.GetNames(IotHubProtocol.GetType()))}).\nDefault: {Enum.GetName(IotHubProtocol.GetType(), IotHubProtocol)}",

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -402,6 +402,7 @@ namespace OpcPublisher
                 }
 
                 // read telemetry configuration file
+                PublisherTelemetryConfiguration.Init();
                 if (!await PublisherTelemetryConfiguration.ReadConfigAsync())
                 {
                     return;
@@ -472,6 +473,7 @@ namespace OpcPublisher
                 await Diagnostics.Shutdown();
 
                 // free resources
+                PublisherTelemetryConfiguration.Deinit();
                 PublisherNodeConfiguration.Deinit();
                 ShutdownTokenSource = null;
             }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -19,6 +19,7 @@ namespace OpcPublisher
     using static OpcSession;
     using static OpcStackConfiguration;
     using static PublisherNodeConfiguration;
+    using static PublisherTelemetryConfiguration;
     using static System.Console;
 
     public class Program
@@ -51,6 +52,7 @@ namespace OpcPublisher
                 Mono.Options.OptionSet options = new Mono.Options.OptionSet {
                     // Publishing configuration options
                     { "pf|publishfile=", $"the filename to configure the nodes to publish.\nDefault: '{PublisherNodeConfigurationFilename}'", (string p) => PublisherNodeConfigurationFilename = p },
+                    { "tc|telemetryconfigfile=", $"the filename to configure the ingested telemetry\nDefault: '{PublisherTelemetryConfigurationFilename}'", (string p) => PublisherTelemetryConfigurationFilename = p },
                     { "sd|shopfloordomain=", $"the domain of the shopfloor. if specified this domain is appended (delimited by a ':' to the 'ApplicationURI' property when telemetry is sent to IoTHub.\n" +
                             "The value must follow the syntactical rules of a DNS hostname.\nDefault: not set", (string s) => {
                             Regex domainNameRegex = new Regex("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
@@ -399,7 +401,13 @@ namespace OpcPublisher
                     return;
                 }
 
-                // Read node configuration file
+                // read telemetry configuration file
+                if (!await PublisherTelemetryConfiguration.ReadConfigAsync())
+                {
+                    return;
+                }
+
+                // read node configuration file
                 PublisherNodeConfiguration.Init();
                 if (!await PublisherNodeConfiguration.ReadConfigAsync())
                 {

--- a/src/PublisherNodeConfiguration.cs
+++ b/src/PublisherNodeConfiguration.cs
@@ -315,7 +315,7 @@ namespace OpcPublisher
                                         }
                                         else
                                         {
-                                            opcNodeOnEndpointUrl.ExpandedNodeId = monitoredItem.ConfigExpandedNodeId.ToString();
+                                            opcNodeOnEndpointUrl.ExpandedNodeId = monitoredItem.ConfigExpandedNodeIdOriginal.ToString();
                                             opcNodeOnEndpointUrl.OpcPublishingInterval = (int)subscription.RequestedPublishingInterval;
                                             opcNodeOnEndpointUrl.OpcSamplingInterval = monitoredItem.RequestedSamplingInterval;
                                             if (publisherConfigurationFileEntry.OpcNodes == null)
@@ -388,9 +388,13 @@ namespace OpcPublisher
     public class OpcNodeOnEndpointUrl
     {
         public string ExpandedNodeId;
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+
+        [DefaultValue(OpcSamplingIntervalDefault)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, NullValueHandling = NullValueHandling.Ignore)]
         public int? OpcSamplingInterval;
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+
+        [DefaultValue(OpcPublishingIntervalDefault)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, NullValueHandling = NullValueHandling.Ignore)]
         public int? OpcPublishingInterval;
     }
 

--- a/src/PublisherNodeConfiguration.cs
+++ b/src/PublisherNodeConfiguration.cs
@@ -300,6 +300,7 @@ namespace OpcPublisher
                                         {
                                             PublisherConfigurationFileEntry legacyPublisherConfigFileEntry = new PublisherConfigurationFileEntry();
                                             legacyPublisherConfigFileEntry.EndpointUri = session.EndpointUri;
+                                            legacyPublisherConfigFileEntry.UseSecurity = session.UseSecurity;
                                             legacyPublisherConfigFileEntry.NodeId = new NodeId(monitoredItem.ConfigExpandedNodeId.Identifier, (ushort)session.GetNamespaceIndex(monitoredItem.ConfigExpandedNodeId?.NamespaceUri));
                                             publisherConfigurationFileEntries.Add(legacyPublisherConfigFileEntry);
                                         }
@@ -323,6 +324,7 @@ namespace OpcPublisher
                                         // server namespace array.
                                         PublisherConfigurationFileEntry legacyPublisherConfigFileEntry = new PublisherConfigurationFileEntry();
                                         legacyPublisherConfigFileEntry.EndpointUri = session.EndpointUri;
+                                        legacyPublisherConfigFileEntry.UseSecurity = session.UseSecurity;
                                         legacyPublisherConfigFileEntry.NodeId = monitoredItem.ConfigNodeId;
                                         publisherConfigurationFileEntries.Add(legacyPublisherConfigFileEntry);
                                     }
@@ -405,8 +407,8 @@ namespace OpcPublisher
         public Uri EndpointUri { get; set; }
 
         [DefaultValue(true)]
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public bool UseSecurity { get; set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore)]
+        public bool? UseSecurity { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public NodeId NodeId { get; set; }
@@ -427,21 +429,21 @@ namespace OpcPublisher
         public int OpcSamplingInterval;
         public int OpcPublishingInterval;
 
-        public NodePublishingConfiguration(NodeId nodeId, Uri endpointUri, bool useSecurity, int opcSamplingInterval, int opcPublishingInterval)
+        public NodePublishingConfiguration(NodeId nodeId, Uri endpointUri, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
         {
             NodeId = nodeId;
             ExpandedNodeId = null;
             EndpointUri = endpointUri;
-            UseSecurity = useSecurity;
+            UseSecurity = useSecurity ?? true;
             OpcSamplingInterval = opcSamplingInterval;
             OpcPublishingInterval = opcPublishingInterval;
         }
-        public NodePublishingConfiguration(ExpandedNodeId expandedNodeId, Uri endpointUri, bool useSecurity, int opcSamplingInterval, int opcPublishingInterval)
+        public NodePublishingConfiguration(ExpandedNodeId expandedNodeId, Uri endpointUri, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
         {
             NodeId = null;
             ExpandedNodeId = expandedNodeId;
             EndpointUri = endpointUri;
-            UseSecurity = useSecurity;
+            UseSecurity = useSecurity ?? true;
             OpcSamplingInterval = opcSamplingInterval;
             OpcPublishingInterval = opcPublishingInterval;
         }

--- a/src/PublisherNodeConfiguration.cs
+++ b/src/PublisherNodeConfiguration.cs
@@ -26,7 +26,6 @@ namespace OpcPublisher
             get => _publisherNodeConfigurationFilename;
             set => _publisherNodeConfigurationFilename = value;
         }
-        private static string _publisherNodeConfigurationFilename = $"{System.IO.Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}publishednodes.json";
 
         public static int NumberOfOpcSessions
         {
@@ -367,6 +366,7 @@ namespace OpcPublisher
             }
         }
 
+        private static string _publisherNodeConfigurationFilename = $"{System.IO.Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}publishednodes.json";
         private static List<NodePublishingConfiguration> _nodePublishingConfiguration;
         private static List<PublisherConfigurationFileEntry> _configurationFileEntries;
     }

--- a/src/PublisherNodeManager.cs
+++ b/src/PublisherNodeManager.cs
@@ -474,7 +474,7 @@ namespace OpcPublisher
                 if (opcSession == null)
                 {
                     // create new session info.
-                    opcSession = new OpcSession(endpointUri, OpcSessionCreationTimeout);
+                    opcSession = new OpcSession(endpointUri, true, OpcSessionCreationTimeout);
                     OpcSessions.Add(opcSession);
                     Trace($"PublishNode: No matching session found for endpoint '{endpointUri.OriginalString}'. Requested to create a new one.");
                 }

--- a/src/PublisherTelemetryConfiguration.cs
+++ b/src/PublisherTelemetryConfiguration.cs
@@ -17,6 +17,15 @@ namespace OpcPublisher
 
     public class PublisherTelemetryConfiguration
     {
+        public const string ApplicationUriKeyDefault = "ApplicationUri";
+        public const string DisplayNameKeyDefault = "DisplayName";
+        public const string ValueKeyDefault = "Value";
+        public const string SourceTimestampKeyDefault = "SourceTimestamp";
+        public const string StatusCodeKeyDefault = "StatusCode";
+        public const string StatusKeyDefault = "Status";
+        public const string EndpointUrlKeyDefault = "EndpointUrl";
+        public const string NodeIdDefault = "NodeId";
+
         public class Settings
         {
             [DefaultValue(true)]
@@ -39,13 +48,13 @@ namespace OpcPublisher
                 {
                     Publish = true,
                     Pattern = null,
-                    Name = "ApplicationUri"
+                    Name = null
                 };
                 DisplayName = new Settings
                 {
                     Publish = true,
                     Pattern = null,
-                    Name = "DisplayName"
+                    Name = null
                 };
             }
 
@@ -67,25 +76,25 @@ namespace OpcPublisher
                 {
                     Publish = true,
                     Pattern = null,
-                    Name = "Value"
+                    Name = null
                 };
                 SourceTimestamp = new Settings
                 {
                     Publish = true,
                     Pattern = null,
-                    Name = "SourceTimestamp"
+                    Name = null
                 };
                 StatusCode = new Settings
                 {
                     Publish = false,
                     Pattern = null,
-                    Name = "StatusCode"
+                    Name = null
                 };
                 Status = new Settings
                 {
                     Publish = false,
                     Pattern = null,
-                    Name = "Status"
+                    Name = null
                 };
             }
 
@@ -112,13 +121,13 @@ namespace OpcPublisher
                 {
                     Publish = false,
                     Pattern = null,
-                    Name = "EndpointUrl"
+                    Name = null
                 };
                 NodeId = new Settings
                 {
                     Publish = true,
                     Pattern = null,
-                    Name = "NodeId"
+                    Name = null
                 };
                 MonitoredItem = new MonitoredItemTelemetryConfiguration();
                 Value = new ValueTelemetryConfiguration();

--- a/src/PublisherTelemetryConfiguration.cs
+++ b/src/PublisherTelemetryConfiguration.cs
@@ -7,142 +7,322 @@ using System.Threading.Tasks;
 
 namespace OpcPublisher
 {
-    using System.ComponentModel;
     using System.IO;
     using System.Linq;
-    using System.Threading;
-    using static OpcMonitoredItem;
+    using System.Text.RegularExpressions;
     using static OpcPublisher.Workarounds.TraceWorkaround;
-    using static OpcStackConfiguration;
 
     public class PublisherTelemetryConfiguration
     {
-        public const string ApplicationUriKeyDefault = "ApplicationUri";
-        public const string DisplayNameKeyDefault = "DisplayName";
-        public const string ValueKeyDefault = "Value";
-        public const string SourceTimestampKeyDefault = "SourceTimestamp";
-        public const string StatusCodeKeyDefault = "StatusCode";
-        public const string StatusKeyDefault = "Status";
-        public const string EndpointUrlKeyDefault = "EndpointUrl";
-        public const string NodeIdDefault = "NodeId";
+        public const string EndpointUrlNameDefault = "EndpointUrl";
+        public const string NodeIdNameDefault = "NodeId";
+        public const string ApplicationUriNameDefault = "ApplicationUri";
+        public const string DisplayNameNameDefault = "DisplayName";
+        public const string ValueNameDefault = "Value";
+        public const string SourceTimestampNameDefault = "SourceTimestamp";
+        public const string StatusNameDefault = "Status";
+        public const string StatusCodeNameDefault = "StatusCode";
 
+        /// <summary>
+        /// Class to control the telemetry publish, name and pattern properties.
+        /// </summary>
         public class Settings
         {
-            [DefaultValue(true)]
-            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-            public bool Publish;
+            public bool? Publish
+            {
+                get => _publish;
+                set
+                {
+                    if (value != null)
+                    {
+                        _publish = value;
+                    }
+                }
+            }
 
-            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-            public string Pattern;
+            public string Name
+            {
+                get => _name;
+                set
+                {
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        _name = value;
+                    }
+                }
+            }
 
-            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-            public string Name;
+            public string Pattern
+            {
+                get => _pattern;
+                set
+                {
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        // validate pattern
+                        try
+                        {
+                            _patternRegex = new Regex(value);
+                            _pattern = value;
+                        }
+                        catch
+                        {
+                            Trace(Utils.TraceMasks.Error, $"The regular expression '{value}' used for the property 'Pattern' is not a valid regular expression. Please change.");
+                            throw new Exception($"The regular expression '{value}' used for the property 'Pattern' is not a valid regular expression. Please change.");
+                        }
+                    }
+                }
+            }
+
+            public Settings()
+            {
+                _publish = null;
+                _name = null;
+                _pattern = null;
+                _patternRegex = null;
+            }
+
+            /// <summary>
+            /// Method to apply the regex to the given value if one is defined, otherwise we return the string passed in.
+            /// </summary>
+            /// <param name="stringToParse"></param>
+            /// <returns></returns>
+            public string PatternMatch(string stringToParse)
+            {
+                // no pattern set, return full string
+                if (_patternRegex == null)
+                {
+                    return stringToParse;
+                }
+
+                // build the result string based on the pattern
+                string result = string.Empty;
+                Match match = _patternRegex.Match(stringToParse);
+                if (match.Groups[0].Success)
+                {
+                    foreach (var group in match.Groups.Skip(1))
+                    {
+                        result += group.Value;
+                    }
+                }
+                return result;
+            }
+
+            private bool? _publish;
+            private string _name;
+            private string _pattern;
+            private Regex _patternRegex;
+
         }
 
+        /// <summary>
+        /// Class to define the MonitoredItem related telemetry configuration.
+        /// </summary>
         public class MonitoredItemTelemetryConfiguration
         {
             public MonitoredItemTelemetryConfiguration()
             {
-                Flat = true;
-                ApplicationUri = new Settings
-                {
-                    Publish = true,
-                    Pattern = null,
-                    Name = null
-                };
-                DisplayName = new Settings
-                {
-                    Publish = true,
-                    Pattern = null,
-                    Name = null
-                };
+                _flat = null;
+                _applicationUri = new Settings();
+                _displayName = new Settings();
             }
 
-            [DefaultValue(false)]
-            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-            public bool Flat;
+            public bool? Flat
+            {
+                get => _flat;
+                set
+                {
+                    if (value != null)
+                    {
+                        _flat = value;
+                    }
+                }
+            }
 
-            public Settings ApplicationUri;
+            public Settings ApplicationUri
+            {
+                get => _applicationUri;
+                set
+                {
+                    _applicationUri.Publish = value.Publish;
+                    _applicationUri.Name = value.Name;
+                    _applicationUri.Pattern = value.Pattern;
+                }
+            }
 
-            public Settings DisplayName;
+
+            public Settings DisplayName
+            {
+                get => _displayName;
+                set
+                {
+                    _displayName.Publish = value.Publish;
+                    _displayName.Name = value.Name;
+                    _displayName.Pattern = value.Pattern;
+                }
+            }
+
+            private bool? _flat;
+            private Settings _applicationUri;
+            private Settings _displayName;
         }
 
+        /// <summary>
+        /// Class to define the Value related telemetry configuration.
+        /// </summary>
         public class ValueTelemetryConfiguration
         {
             public ValueTelemetryConfiguration()
             {
-                Flat = false;
-                Value = new Settings
-                {
-                    Publish = true,
-                    Pattern = null,
-                    Name = null
-                };
-                SourceTimestamp = new Settings
-                {
-                    Publish = true,
-                    Pattern = null,
-                    Name = null
-                };
-                StatusCode = new Settings
-                {
-                    Publish = false,
-                    Pattern = null,
-                    Name = null
-                };
-                Status = new Settings
-                {
-                    Publish = false,
-                    Pattern = null,
-                    Name = null
-                };
+                _flat = null;
+                _value = new Settings();
+                _sourceTimestamp = new Settings();
+                _statusCode = new Settings();
+                _status = new Settings();
             }
 
-            [DefaultValue(false)]
-            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-            public bool Flat;
+            public bool? Flat
+            {
+                get => _flat;
+                set
+                {
+                    if (value != null)
+                    {
+                        _flat = value;
+                    }
+                }
+            }
 
-            public Settings Value;
+            public Settings Value
+            {
+                get => _value;
+                set
+                {
+                    _value.Publish = value.Publish;
+                    _value.Name = value.Name;
+                    _value.Pattern = value.Pattern;
+                }
+            }
 
-            public Settings SourceTimestamp;
+            public Settings SourceTimestamp
+            {
+                get => _sourceTimestamp;
+                set
+                {
+                    _sourceTimestamp.Publish = value.Publish;
+                    _sourceTimestamp.Name = value.Name;
+                    _sourceTimestamp.Pattern = value.Pattern;
+                }
+            }
 
-            public Settings StatusCode;
+            public Settings StatusCode
+            {
+                get => _statusCode;
+                set
+                {
+                    _statusCode.Publish = value.Publish;
+                    _statusCode.Name = value.Name;
+                    _statusCode.Pattern = value.Pattern;
+                }
+            }
 
-            public Settings Status;
-    }
+            public Settings Status
+            {
+                get => _status;
+                set
+                {
+                    _status.Publish = value.Publish;
+                    _status.Name = value.Name;
+                    _status.Pattern = value.Pattern;
+                }
+            }
 
-    public class ServerTelemetryConfiguration
+            private bool? _flat;
+            private Settings _value;
+            private Settings _sourceTimestamp;
+            private Settings _statusCode;
+            private Settings _status;
+        }
+
+        /// <summary>
+        /// Class to define the publisher configuration related telemetry configuration.
+        /// </summary>
+        public class EndpointTelemetryConfiguration
         {
-            public ServerTelemetryConfiguration()
+            public EndpointTelemetryConfiguration()
             {
                 ForEndpointUrl = null;
-
-                EndpointUrl = new Settings
-                {
-                    Publish = false,
-                    Pattern = null,
-                    Name = null
-                };
-                NodeId = new Settings
-                {
-                    Publish = true,
-                    Pattern = null,
-                    Name = null
-                };
-                MonitoredItem = new MonitoredItemTelemetryConfiguration();
-                Value = new ValueTelemetryConfiguration();
+                _endpointUrl = new Settings();
+                _nodeId = new Settings();
+                _monitoredItem = new MonitoredItemTelemetryConfiguration();
+                _value = new ValueTelemetryConfiguration();
             }
-
             public string ForEndpointUrl { get; set; }
 
-            public Settings EndpointUrl { get; set; }
+            public Settings EndpointUrl
+            {
+                get => _endpointUrl;
+                set
+                {
+                    _endpointUrl.Publish = value.Publish;
+                    _endpointUrl.Name = value.Name;
+                    _endpointUrl.Pattern = value.Pattern;
+                }
+            }
 
-            public Settings NodeId { get; set; }
+            public Settings NodeId
+            {
+                get => _nodeId;
+                set
+                {
+                    _nodeId.Publish = value.Publish;
+                    _nodeId.Name = value.Name;
+                    _nodeId.Pattern = value.Pattern;
+                }
+            }
 
-            public MonitoredItemTelemetryConfiguration MonitoredItem { get; set; }
+            public MonitoredItemTelemetryConfiguration MonitoredItem
+            {
+                get => _monitoredItem;
+                set
+                {
+                    _monitoredItem.Flat = value.Flat;
+                    _monitoredItem.ApplicationUri = value.ApplicationUri;
+                    _monitoredItem.DisplayName = value.DisplayName;
+                }
+            }
 
-            public ValueTelemetryConfiguration Value { get; set; }
+            public ValueTelemetryConfiguration Value
+            {
+                get => _value;
+                set
+                {
+                    _value.Flat = value.Flat;
+                    _value.Value = value.Value;
+                    _value.SourceTimestamp = value.SourceTimestamp;
+                    _value.StatusCode = value.StatusCode;
+                    _value.Status = value.Status;
+                }
+            }
 
+            private Settings _endpointUrl;
+            private MonitoredItemTelemetryConfiguration _monitoredItem;
+            private ValueTelemetryConfiguration _value;
+            private Settings _nodeId;
+        }
+
+        /// <summary>
+        /// Class to define the telemetryconfiguration.json configuration file layout.
+        /// </summary>
+        public class TelemetryConfiguration
+        {
+            public EndpointTelemetryConfiguration Defaults;
+            public List<EndpointTelemetryConfiguration> EndpointSpecific;
+
+            public TelemetryConfiguration()
+            {
+                EndpointSpecific = new List<EndpointTelemetryConfiguration>();
+            }
         }
 
         public static string PublisherTelemetryConfigurationFilename
@@ -151,31 +331,183 @@ namespace OpcPublisher
             set => _publisherTelemetryConfigurationFilename = value;
         }
 
-        public static ServerTelemetryConfiguration GetServerTelemetryConfiguration(string endpointUrl)
+        /// <summary>
+        /// Initialize resources for the telemetry configuration.
+        /// </summary>
+        public static void Init()
         {
-            // return the default if there are no others
-            if (_serverTelemetryConfigurations == null || string.IsNullOrEmpty(endpointUrl))
-            {
-                return _defaultServerTelemetryConfiguration;
-            }
-
-            // lookup the configuration for the application URI and return the default if there is none
-            var serverTelemetryConfiguration = _serverTelemetryConfigurations.FirstOrDefault(c => c.ForEndpointUrl.Equals(endpointUrl, StringComparison.OrdinalIgnoreCase));
-            if (serverTelemetryConfiguration == null)
-            {
-                return _defaultServerTelemetryConfiguration;
-            }
-            return serverTelemetryConfiguration;
+            _telemetryConfiguration = null;
+            _endpointTelemetryConfigurations = new List<EndpointTelemetryConfiguration>();
+            _defaultEndpointTelemetryConfiguration = null;
+            _endpointTelemetryConfigurationCache = new Dictionary<string, EndpointTelemetryConfiguration>();
         }
 
         /// <summary>
-        /// Read and parse the publisher node configuration file.
+        /// Frees resources for the telemetry configuration.
         /// </summary>
-        /// <returns></returns>
+        public static void Deinit()
+        {
+            _publisherTelemetryConfigurationFilename = null;
+            _telemetryConfiguration = null;
+            _endpointTelemetryConfigurations = null;
+            _defaultEndpointTelemetryConfiguration = null;
+            _endpointTelemetryConfigurationCache = null;
+        }
+
+
+        /// <summary>
+        /// Method to get the telemetry configuration for a specific endpoint URL. If the endpoint URL is not found, then the default configuration is returned.
+        /// </summary>
+        public static EndpointTelemetryConfiguration GetEndpointTelemetryConfiguration(string endpointUrl)
+        {
+            // lookup configuration in cache and return it or return default configuration
+            if (_endpointTelemetryConfigurationCache.ContainsKey(endpointUrl))
+            {
+                return _endpointTelemetryConfigurationCache[endpointUrl];
+            }
+            return _defaultEndpointTelemetryConfiguration;
+        }
+
+        /// <summary>
+        /// Validate the endpoint configuration. 'Name' and 'Flat' properties are not allowed and there is only one configuration per endpoint allowed.
+        /// </summary>
+        private static bool ValidateEndpointConfiguration(EndpointTelemetryConfiguration config)
+        {
+            if (config.ForEndpointUrl == null)
+            {
+                Trace(Utils.TraceMasks.Error, "Each object in the 'EndpointSpecific' array must have a property 'ForEndpointUrl'. Please change.");
+                return false;
+
+            }
+            if (_telemetryConfiguration.EndpointSpecific.Count(c => !string.IsNullOrEmpty(c.ForEndpointUrl) && c.ForEndpointUrl.Equals(config?.ForEndpointUrl, StringComparison.OrdinalIgnoreCase)) > 1)
+            {
+                Trace(Utils.TraceMasks.Error, $"The value '{config.ForEndpointUrl}' for property 'ForEndpointUrl' is only allowed to used once in the 'EndpointSpecific' array. Please change.");
+                return false;
+            }
+            if (config.EndpointUrl.Name != null || config.NodeId.Name != null ||
+                config.MonitoredItem.ApplicationUri.Name != null || config.MonitoredItem.DisplayName.Name != null ||
+                config.Value.Value.Name != null || config.Value.SourceTimestamp.Name != null || config.Value.StatusCode.Name != null || config.Value.Status.Name != null)
+            {
+                Trace(Utils.TraceMasks.Error, "The property 'Name' is not allowed in any object in the 'EndpointSpecific' array. Please change.");
+                return false;
+            }
+            if (config.MonitoredItem.Flat != null || config.Value.Flat != null)
+            {
+                Trace(Utils.TraceMasks.Error, "The property 'Flat' is not allowed in any object in the 'EndpointSpecific' array. Please change.");
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Initialize the default configuration to be compatible with Connected factory Preconfigured Solution.
+        /// </summary>
+        private static void InitializePublisherDefaultEndpointTelemetryConfiguration()
+        {
+            // create the default configuration
+            _defaultEndpointTelemetryConfiguration = new EndpointTelemetryConfiguration();
+
+            // set defaults for 'Name' to be compatible with Connected factory
+            _defaultEndpointTelemetryConfiguration.EndpointUrl.Name = EndpointUrlNameDefault;
+            _defaultEndpointTelemetryConfiguration.NodeId.Name = NodeIdNameDefault;
+            _defaultEndpointTelemetryConfiguration.MonitoredItem.ApplicationUri.Name = ApplicationUriNameDefault;
+            _defaultEndpointTelemetryConfiguration.MonitoredItem.DisplayName.Name = DisplayNameNameDefault;
+            _defaultEndpointTelemetryConfiguration.Value.Value.Name = ValueNameDefault;
+            _defaultEndpointTelemetryConfiguration.Value.SourceTimestamp.Name = SourceTimestampNameDefault;
+            _defaultEndpointTelemetryConfiguration.Value.StatusCode.Name = StatusCodeNameDefault;
+            _defaultEndpointTelemetryConfiguration.Value.Status.Name = StatusCodeNameDefault;
+
+            // set defaults for 'Publish' to be compatible with Connected factory
+            _defaultEndpointTelemetryConfiguration.EndpointUrl.Publish = false;
+            _defaultEndpointTelemetryConfiguration.NodeId.Publish = true;
+            _defaultEndpointTelemetryConfiguration.MonitoredItem.ApplicationUri.Publish = true;
+            _defaultEndpointTelemetryConfiguration.MonitoredItem.DisplayName.Publish = true;
+            _defaultEndpointTelemetryConfiguration.Value.Value.Publish = true;
+            _defaultEndpointTelemetryConfiguration.Value.SourceTimestamp.Publish = true;
+            _defaultEndpointTelemetryConfiguration.Value.StatusCode.Publish = false;
+            _defaultEndpointTelemetryConfiguration.Value.Status.Publish = false;
+
+            // set defaults for 'Flat' to be compatible with Connected factory
+            _defaultEndpointTelemetryConfiguration.MonitoredItem.Flat = true;
+            _defaultEndpointTelemetryConfiguration.Value.Flat = false;
+
+            // 'Pattern' is set to null on creation which is whats default
+        }
+
+        /// <summary>
+        /// Update the default configuration with the settings give in the 'Defaults' object of the configuration file.
+        /// </summary>
+        public static bool UpdateDefaultEndpointTelemetryConfiguration()
+        {
+            // sanity check user default configuration
+            if (_telemetryConfiguration.Defaults != null)
+            {
+                if (_telemetryConfiguration.Defaults.ForEndpointUrl != null)
+                {
+                    Trace(Utils.TraceMasks.Error, "The property 'ForEndpointUrl' is not allowed in 'Defaults'. Please change.");
+                    return false;
+                }
+
+                // process all properties
+                _defaultEndpointTelemetryConfiguration.EndpointUrl = _telemetryConfiguration.Defaults.EndpointUrl;
+                _defaultEndpointTelemetryConfiguration.NodeId = _telemetryConfiguration.Defaults.NodeId;
+                _defaultEndpointTelemetryConfiguration.MonitoredItem = _telemetryConfiguration.Defaults.MonitoredItem;
+                _defaultEndpointTelemetryConfiguration.Value = _telemetryConfiguration.Defaults.Value;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Update the endpoint specific telemetry configuration using settings from the default configuration.
+        /// Only those settings are applied, which are not defined by the endpoint specific configuration.
+        /// </summary>
+        public static void UpdateEndpointTelemetryConfiguration(EndpointTelemetryConfiguration config)
+        {
+            // process all properties, applying only those defaults which are not set in the endpoint specific config
+            config.EndpointUrl.Name = config.EndpointUrl.Name ?? _defaultEndpointTelemetryConfiguration.EndpointUrl.Name;
+            config.EndpointUrl.Publish = config.EndpointUrl.Publish ?? _defaultEndpointTelemetryConfiguration.EndpointUrl.Publish;
+            config.EndpointUrl.Pattern = config.EndpointUrl.Pattern ?? _defaultEndpointTelemetryConfiguration.EndpointUrl.Pattern;
+
+            config.NodeId.Name = config.NodeId.Name ?? _defaultEndpointTelemetryConfiguration.NodeId.Name;
+            config.NodeId.Publish = config.NodeId.Publish ?? _defaultEndpointTelemetryConfiguration.NodeId.Publish;
+            config.NodeId.Pattern = config.NodeId.Pattern ?? _defaultEndpointTelemetryConfiguration.NodeId.Pattern;
+
+            config.MonitoredItem.Flat = config.MonitoredItem.Flat ?? _defaultEndpointTelemetryConfiguration.MonitoredItem.Flat;
+
+            config.MonitoredItem.ApplicationUri.Name = config.MonitoredItem.ApplicationUri.Name ?? _defaultEndpointTelemetryConfiguration.MonitoredItem.ApplicationUri.Name;
+            config.MonitoredItem.ApplicationUri.Publish = config.MonitoredItem.ApplicationUri.Publish ?? _defaultEndpointTelemetryConfiguration.MonitoredItem.ApplicationUri.Publish;
+            config.MonitoredItem.ApplicationUri.Pattern = config.MonitoredItem.ApplicationUri.Pattern ?? _defaultEndpointTelemetryConfiguration.MonitoredItem.ApplicationUri.Pattern;
+
+            config.MonitoredItem.DisplayName.Name = config.MonitoredItem.DisplayName.Name ?? _defaultEndpointTelemetryConfiguration.MonitoredItem.DisplayName.Name;
+            config.MonitoredItem.DisplayName.Publish = config.MonitoredItem.DisplayName.Publish ?? _defaultEndpointTelemetryConfiguration.MonitoredItem.DisplayName.Publish;
+            config.MonitoredItem.DisplayName.Pattern = config.MonitoredItem.DisplayName.Pattern ?? _defaultEndpointTelemetryConfiguration.MonitoredItem.DisplayName.Pattern;
+
+            config.Value.Flat = config.Value.Flat ?? _defaultEndpointTelemetryConfiguration.Value.Flat;
+
+            config.Value.Value.Name = config.Value.Value.Name ?? _defaultEndpointTelemetryConfiguration.Value.Value.Name;
+            config.Value.Value.Publish = config.Value.Value.Publish ?? _defaultEndpointTelemetryConfiguration.Value.Value.Publish;
+            config.Value.Value.Pattern = config.Value.Value.Pattern ?? _defaultEndpointTelemetryConfiguration.Value.Value.Pattern;
+
+            config.Value.SourceTimestamp.Name = config.Value.SourceTimestamp.Name ?? _defaultEndpointTelemetryConfiguration.Value.SourceTimestamp.Name;
+            config.Value.SourceTimestamp.Publish = config.Value.SourceTimestamp.Publish ?? _defaultEndpointTelemetryConfiguration.Value.SourceTimestamp.Publish;
+            config.Value.SourceTimestamp.Pattern = config.Value.SourceTimestamp.Pattern ?? _defaultEndpointTelemetryConfiguration.Value.SourceTimestamp.Pattern;
+
+            config.Value.StatusCode.Name = config.Value.StatusCode.Name ?? _defaultEndpointTelemetryConfiguration.Value.StatusCode.Name;
+            config.Value.StatusCode.Publish = config.Value.StatusCode.Publish ?? _defaultEndpointTelemetryConfiguration.Value.StatusCode.Publish;
+            config.Value.StatusCode.Pattern = config.Value.StatusCode.Pattern ?? _defaultEndpointTelemetryConfiguration.Value.StatusCode.Pattern;
+
+            config.Value.Status.Name = config.Value.Status.Name ?? _defaultEndpointTelemetryConfiguration.Value.Status.Name;
+            config.Value.Status.Publish = config.Value.Status.Publish ?? _defaultEndpointTelemetryConfiguration.Value.Status.Publish;
+            config.Value.Status.Pattern = config.Value.Status.Pattern ?? _defaultEndpointTelemetryConfiguration.Value.Status.Pattern;
+        }
+
+        /// <summary>
+        /// Read and parse the publisher telemetry configuration file.
+        /// </summary>
         public static async Task<bool> ReadConfigAsync()
         {
-            // initialize the default server telemetry configuration
-            _defaultServerTelemetryConfiguration = new ServerTelemetryConfiguration();
+            // initialize with the default server telemetry configuration
+           InitializePublisherDefaultEndpointTelemetryConfiguration();
 
             // return if there is no configuration file specified
             if (string.IsNullOrEmpty(_publisherTelemetryConfigurationFilename))
@@ -184,19 +516,32 @@ namespace OpcPublisher
                 return true;
             }
 
-            // get information on the telemetry configuration and validate the json by deserializing it
+            // get information on the telemetry configuration
             try
             {
                 Trace($"Attempting to load telemetry configuration file from: {_publisherTelemetryConfigurationFilename}");
-                _serverTelemetryConfigurations = JsonConvert.DeserializeObject<List<ServerTelemetryConfiguration>>(File.ReadAllText(_publisherTelemetryConfigurationFilename));
+                _telemetryConfiguration = JsonConvert.DeserializeObject<TelemetryConfiguration>(File.ReadAllText(_publisherTelemetryConfigurationFilename));
 
-                // use default telemetry configuration from file, if there was one specified
-                ServerTelemetryConfiguration defaultServerTelemetryConfiguration = _serverTelemetryConfigurations.FirstOrDefault(c => string.IsNullOrEmpty(c.ForEndpointUrl));
-                if (defaultServerTelemetryConfiguration != null)
+                // update the default configuration with the 'Defaults' settings from the configuration file
+                if (UpdateDefaultEndpointTelemetryConfiguration() == false)
                 {
-                    _defaultServerTelemetryConfiguration = defaultServerTelemetryConfiguration;
-                    // remove the default configuration
-                    _serverTelemetryConfigurations.Remove(defaultServerTelemetryConfiguration);
+                    return false;
+                }
+
+                // sanity check all endpoint specific configurations and add them to the lookup dictionary
+                foreach (var config in _telemetryConfiguration.EndpointSpecific)
+                {
+                    // validate the endpoint specific telemetry configuration
+                    if (ValidateEndpointConfiguration(config) == false)
+                    {
+                        return false;
+                    }
+
+                    // set defaults for unset values
+                    UpdateEndpointTelemetryConfiguration(config);
+
+                    // add the endpoint configuration to the lookup cache
+                    _endpointTelemetryConfigurationCache.Add(config.ForEndpointUrl, config);
                 }
             }
             catch (Exception e)
@@ -209,7 +554,9 @@ namespace OpcPublisher
         }
 
         private static string _publisherTelemetryConfigurationFilename = null;
-        private static List<ServerTelemetryConfiguration> _serverTelemetryConfigurations;
-        private static ServerTelemetryConfiguration _defaultServerTelemetryConfiguration;
+        private static TelemetryConfiguration _telemetryConfiguration;
+        private static List<EndpointTelemetryConfiguration> _endpointTelemetryConfigurations;
+        private static EndpointTelemetryConfiguration _defaultEndpointTelemetryConfiguration;
+        private static Dictionary<string, EndpointTelemetryConfiguration> _endpointTelemetryConfigurationCache;
     }
 }

--- a/src/PublisherTelemetryConfiguration.cs
+++ b/src/PublisherTelemetryConfiguration.cs
@@ -1,0 +1,206 @@
+﻿
+using Newtonsoft.Json;
+using Opc.Ua;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OpcPublisher
+{
+    using System.ComponentModel;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using static OpcMonitoredItem;
+    using static OpcPublisher.Workarounds.TraceWorkaround;
+    using static OpcStackConfiguration;
+
+    public class PublisherTelemetryConfiguration
+    {
+        public class Settings
+        {
+            [DefaultValue(true)]
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public bool Publish;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public string Pattern;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public string Name;
+        }
+
+        public class MonitoredItemTelemetryConfiguration
+        {
+            public MonitoredItemTelemetryConfiguration()
+            {
+                Flat = true;
+                ApplicationUri = new Settings
+                {
+                    Publish = true,
+                    Pattern = null,
+                    Name = "ApplicationUri"
+                };
+                DisplayName = new Settings
+                {
+                    Publish = true,
+                    Pattern = null,
+                    Name = "DisplayName"
+                };
+            }
+
+            [DefaultValue(false)]
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public bool Flat;
+
+            public Settings ApplicationUri;
+
+            public Settings DisplayName;
+        }
+
+        public class ValueTelemetryConfiguration
+        {
+            public ValueTelemetryConfiguration()
+            {
+                Flat = false;
+                Value = new Settings
+                {
+                    Publish = true,
+                    Pattern = null,
+                    Name = "Value"
+                };
+                SourceTimestamp = new Settings
+                {
+                    Publish = true,
+                    Pattern = null,
+                    Name = "SourceTimestamp"
+                };
+                StatusCode = new Settings
+                {
+                    Publish = false,
+                    Pattern = null,
+                    Name = "StatusCode"
+                };
+                Status = new Settings
+                {
+                    Publish = false,
+                    Pattern = null,
+                    Name = "Status"
+                };
+            }
+
+            [DefaultValue(false)]
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public bool Flat;
+
+            public Settings Value;
+
+            public Settings SourceTimestamp;
+
+            public Settings StatusCode;
+
+            public Settings Status;
+    }
+
+    public class ServerTelemetryConfiguration
+        {
+            public ServerTelemetryConfiguration()
+            {
+                ForEndpointUrl = null;
+
+                EndpointUrl = new Settings
+                {
+                    Publish = false,
+                    Pattern = null,
+                    Name = "EndpointUrl"
+                };
+                NodeId = new Settings
+                {
+                    Publish = true,
+                    Pattern = null,
+                    Name = "NodeId"
+                };
+                MonitoredItem = new MonitoredItemTelemetryConfiguration();
+                Value = new ValueTelemetryConfiguration();
+            }
+
+            public string ForEndpointUrl { get; set; }
+
+            public Settings EndpointUrl { get; set; }
+
+            public Settings NodeId { get; set; }
+
+            public MonitoredItemTelemetryConfiguration MonitoredItem { get; set; }
+
+            public ValueTelemetryConfiguration Value { get; set; }
+
+        }
+
+        public static string PublisherTelemetryConfigurationFilename
+        {
+            get => _publisherTelemetryConfigurationFilename;
+            set => _publisherTelemetryConfigurationFilename = value;
+        }
+
+        public static ServerTelemetryConfiguration GetServerTelemetryConfiguration(string endpointUrl)
+        {
+            // return the default if there are no others
+            if (_serverTelemetryConfigurations == null || string.IsNullOrEmpty(endpointUrl))
+            {
+                return _defaultServerTelemetryConfiguration;
+            }
+
+            // lookup the configuration for the application URI and return the default if there is none
+            var serverTelemetryConfiguration = _serverTelemetryConfigurations.FirstOrDefault(c => c.ForEndpointUrl.Equals(endpointUrl, StringComparison.OrdinalIgnoreCase));
+            if (serverTelemetryConfiguration == null)
+            {
+                return _defaultServerTelemetryConfiguration;
+            }
+            return serverTelemetryConfiguration;
+        }
+
+        /// <summary>
+        /// Read and parse the publisher node configuration file.
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<bool> ReadConfigAsync()
+        {
+            // initialize the default server telemetry configuration
+            _defaultServerTelemetryConfiguration = new ServerTelemetryConfiguration();
+
+            // return if there is no configuration file specified
+            if (string.IsNullOrEmpty(_publisherTelemetryConfigurationFilename))
+            {
+                Trace("Using default telemetry configuration.");
+                return true;
+            }
+
+            // get information on the telemetry configuration and validate the json by deserializing it
+            try
+            {
+                Trace($"Attempting to load telemetry configuration file from: {_publisherTelemetryConfigurationFilename}");
+                _serverTelemetryConfigurations = JsonConvert.DeserializeObject<List<ServerTelemetryConfiguration>>(File.ReadAllText(_publisherTelemetryConfigurationFilename));
+
+                // use default telemetry configuration from file, if there was one specified
+                ServerTelemetryConfiguration defaultServerTelemetryConfiguration = _serverTelemetryConfigurations.FirstOrDefault(c => string.IsNullOrEmpty(c.ForEndpointUrl));
+                if (defaultServerTelemetryConfiguration != null)
+                {
+                    _defaultServerTelemetryConfiguration = defaultServerTelemetryConfiguration;
+                    // remove the default configuration
+                    _serverTelemetryConfigurations.Remove(defaultServerTelemetryConfiguration);
+                }
+            }
+            catch (Exception e)
+            {
+                Trace(e, "Loading of the telemetry configuration file failed. Does the file exist and has correct syntax?");
+                Trace("exiting...");
+                return false;
+            }
+            return true;
+        }
+
+        private static string _publisherTelemetryConfigurationFilename = null;
+        private static List<ServerTelemetryConfiguration> _serverTelemetryConfigurations;
+        private static ServerTelemetryConfiguration _defaultServerTelemetryConfiguration;
+    }
+}

--- a/src/publishednodes.json
+++ b/src/publishednodes.json
@@ -2,8 +2,8 @@
     {
         // example for an EnpointUrl is: opc.tcp://win10iot:51210/UA/SampleServer
         "EndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
-        // Allows to access the endpoint with SecurityPolicy.None (no signing and encryption applied to the OPC UA communication), default is true
-        "UseSecurity": false,
+        // Allows to access the endpoint with SecurityPolicy.None when set to 'false' (no signing and encryption applied to the OPC UA communication), default is true
+        "UseSecurity": true,
         "OpcNodes": [
             // Publisher will request the server at EndpointUrl to sample the node with the OPC sampling interval specified on command line (or the default value: OPC publishing interval)
             // and the subscription will publish the node value with the OPC publishing interval specified on command line (or the default value: server revised publishing interval).

--- a/src/publishednodes.json
+++ b/src/publishednodes.json
@@ -2,6 +2,8 @@
     {
         // example for an EnpointUrl is: opc.tcp://win10iot:51210/UA/SampleServer
         "EndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
+        // Allows to access the endpoint with SecurityPolicy.None (no signing and encryption applied to the OPC UA communication), default is true
+        "UseSecurity": false,
         "OpcNodes": [
             // Publisher will request the server at EndpointUrl to sample the node with the OPC sampling interval specified on command line (or the default value: OPC publishing interval)
             // and the subscription will publish the node value with the OPC publishing interval specified on command line (or the default value: server revised publishing interval).

--- a/src/telemetryconfiguration.json
+++ b/src/telemetryconfiguration.json
@@ -13,7 +13,7 @@
 //      "DisplayName": "CurrentTime",
 //      "Value": {
 //          "Value": "10.11.2017 14:03:17",
-//          "SourceTimestamp": "2017-11-10 14:03:17Z"
+//          "SourceTimestamp": "2017-11-10T14:03:17Z"
 //      }
 //  }
 
@@ -101,7 +101,7 @@
             // members won't be nested:
             //      "DisplayName": "CurrentTime",
             //      "Value": "10.11.2017 14:03:17",
-            //      "SourceTimestamp": "2017-11-10 14:03:17Z"
+            //      "SourceTimestamp": "2017-11-10T14:03:17Z"
             // The 'Flat' property could only be used for the 'MonitoredItem' and 'Value'
             // configuratíon settings of the 'Defaults' objet and will be used for all JSON
             // messages sent by publisher.
@@ -115,10 +115,11 @@
                 "Publish": true,
                 "Name": "SourceTimestamp"
             },
-            // StatusCode is the 32 bit OPC UA status code formatted as hexadezimal number.
+            // 'StatusCode' is the 32 bit OPC UA status code
             "StatusCode": {
                 "Publish": false,
                 "Name": "StatusCode"
+                // 'Pattern' is ignored for the 'StatusCode' value
             },
             // 'Status' is the symbolic name of 'StatusCode'
             "Status": {

--- a/src/telemetryconfiguration.json
+++ b/src/telemetryconfiguration.json
@@ -1,0 +1,123 @@
+[
+    // The configuration file consists of an array of JSON objects.
+    // If the object has a key "ForEndpointUrl" (as the second object in this sample), the object defines the telemetry configuration for data from this specific endpoint.
+    // The value of "ForEndpointUrl" needs to be the same as is used in publishednodes.json.
+    // If there is no key "ForEndpointUrl" (as in the first object in this sample), the configuration is overwritting OpcPublisher's default telemetry configuration.
+
+    // The next object is overwritting the default telemetry configuration options of OpcPublisher. Here most of the settings are identical what is used as defalut settings.
+    {
+        // The first two keys ('EndpointUrl' and 'NodeId' are configuring the properties taken from the OpcPublisher node configuration object.
+
+        // This is the value of the EndpointUrl configuration from the publishednodes.json file of the node the change happened.
+        "EndpointUrl": {
+            // The following three keys can be used to configure the telemetry of the property.
+            // Publish controls if the property should be part of the telemetry sent to IoTHub.
+            "Publish": false,
+            // Pattern is a regular expression, which is applied to the actual value of the property (here Endpoint).
+            // If this key is ommited, then no regex matching is done, which improves performance.
+            // If the key is used you need to define groups in the regular expression. Publisher applies the
+            // regular expression and then concatenates all groups and use the resulting string as the value to sent to IoTHub.
+            // This example mimics the default behaviour and defines a group which matches the conplete value.
+            "Pattern": "(.*)",
+            // Name allows you to use a shorter string as key in the JSON message sent to IoTHub. By default the key is the same as the property name (EndpointUrl in our case).
+            "Name": "EndpointUrl"
+        },
+        "NodeId": {
+            "Publish": true,
+            "Name": "NodeId"
+        },
+
+        // The MonitoredItem object is configuring the properties taken from the MonitoredItem OPC UA object.
+        "MonitoredItem": {
+            // The 'Flat' key is only used in the 'MonitoredItem' and 'Value' object of this JSON. When set to true, then the properties configured here,
+            // will be added as top level keys to the JSON message. When set to false, the properties will be put in a object with name 'MonitoredItem' into the
+            // JSON message.
+            "Flat": true,
+            "ApplicationUri": {
+                "Publish": true,
+                "Name": "ApplicationUri"
+            },
+            "DisplayName": {
+                "Publish": true,
+                "Name": "DisplayName"
+            }
+        },
+        // The Value object is configuring the properties taken from the event object the OPC UA stack provided in the value change notification event.
+        "Value": {
+            // 'Flat' is here set to false, which will result in an 'Value' object created in the JSON message, which has contains the properties configured below.
+            "Flat": false,
+            "Value": {
+                "Publish": true,
+                "Name": "Value"
+            },
+            "SourceTimestamp": {
+                "Publish": true,
+                "Name": "SourceTimestamp"
+            },
+            // StatusCode is the 32 bit OPC UA status code formatted as hexadezimal number.
+            "StatusCode": {
+                // 'Publish' is false, which means 'StatusCode' will not be part of the JSON message.
+                "Publish": false,
+                "Name": "StatusCode"
+            },
+            // 'Status' is the symbolic name of 'StatusCode'
+            "Status": {
+                "Publish": false,
+                "Name": "Status"
+            }
+        }
+    },
+    {
+        // In this object we configure the telemetry, which is generated for all notification we get from the endpoint specified
+        // be the key 'ForEndpointUrl'. The value of this key, is typically an endpoint URL configured in the publishednodes.json configuration file.
+        "ForEndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
+        "EndpointUrl": {
+            // We overwrite the default behaviour and publish the endpoint URL in this case.
+            "Publish": true,
+            // We also do not use 'EndpointUrl' as key, but save payload in the ingested message and just use 'eu'
+            "Name": "eu"
+        },
+        "NodeId": {
+            // We are not interested in the configured 'NodeId' value, so we do not publish it.
+            "Publish": false
+        },
+        "MonitoredItem": {
+            "Flat": false,
+            "ApplicationUri": {
+                // We already publish the endpoint URL, so we do not need the ApplicationUri of the MonitoredItem to be published.
+                "Publish": false
+            },
+            "DisplayName": {
+                "Publish": true,
+                // Our server is configured to hold enough identification information in the DisplayName (which is the OPC UA nodeId if --fd is not used).
+                // But we are only interested in the meaningful part of the actual DisplayName property, so we define a regex which defines a group for this part
+                // of the DisplayName we are interested in.
+                "Pattern": "ns=.;s=(.*)",
+                // We optimize for minimal JSON message size and use a short key
+                "Name": "dn"
+            }
+        },
+        "Value": {
+            // We have no need for a 'Value' object in the JSON message and go for a completley flat JSON message sent to IoTHub.
+            "Flat": true,
+            "Name": "Value",
+            "Value": {
+                // The value of the node is important for us, everything else we are not interested in to keep the data ingest as small as possible.
+                "Publish": true,
+                "Name": "Value"
+            },
+            "SourceTimestamp": {
+                "Publish": false,
+                "Name": "SourceTimestamp"
+            },
+            "StatusCode": {
+                "Publish": false,
+                "Name": "StatusCode"
+            },
+            "Status": {
+                "Publish": false,
+                "Name": "Status"
+            }
+        }
+    }
+]

--- a/src/telemetryconfiguration.json
+++ b/src/telemetryconfiguration.json
@@ -1,38 +1,89 @@
-[
-    // The configuration file consists of an array of JSON objects.
-    // If the object has a key "ForEndpointUrl" (as the second object in this sample), the object defines the telemetry configuration for data from this specific endpoint.
-    // The value of "ForEndpointUrl" needs to be the same as is used in publishednodes.json.
-    // If there is no key "ForEndpointUrl" (as in the first object in this sample), the configuration is overwritting OpcPublisher's default telemetry configuration.
+// The configuration file consists of two objects:
+// 1) The 'Defaults' object, which defines default settings for the telemetry
+//    configuration as well as a few control settings.
+// 2) An array 'EndpointSpecific' of endpoint specific configuration settings
+// Both objects are optional and if they are not specified, then publisher uses
+// its internal default configuration, which generates telemetry messages compatible
+// with the Microsoft Connected factory Preconfigured Solution (https://github.com/Azure/azure-iot-connected-factory).
 
-    // The next object is overwritting the default telemetry configuration options of OpcPublisher. Here most of the settings are identical what is used as defalut settings.
-    {
-        // The first two keys ('EndpointUrl' and 'NodeId' are configuring the properties taken from the OpcPublisher node configuration object.
+// A JSON telemetry message for Connected factory looks like:
+//  {
+//      "NodeId": "i=2058",
+//      "ApplicationUri": "urn:myopcserver",
+//      "DisplayName": "CurrentTime",
+//      "Value": {
+//          "Value": "10.11.2017 14:03:17",
+//          "SourceTimestamp": "2017-11-10 14:03:17Z"
+//      }
+//  }
 
-        // This is the value of the EndpointUrl configuration from the publishednodes.json file of the node the change happened.
+// The settings of 'Defaults' in the sample below, are similar to what publisher is
+// using as its internal default telemetry configuration.
+{
+    "Defaults": {
+        // The first two properties ('EndpointUrl' and 'NodeId' are configuring data
+        // taken from the OpcPublisher node configuration.
         "EndpointUrl": {
-            // The following three keys can be used to configure the telemetry of the property.
-            // Publish controls if the property should be part of the telemetry sent to IoTHub.
+
+            // The following three properties can be used to configure the 'EndpointUrl'
+            // property in the JSON message send by publisher to IoTHub.
+
+            // Publish controls if the property should be part of the JSON message at all.
             "Publish": false,
-            // Pattern is a regular expression, which is applied to the actual value of the property (here Endpoint).
-            // If this key is ommited, then no regex matching is done, which improves performance.
-            // If the key is used you need to define groups in the regular expression. Publisher applies the
-            // regular expression and then concatenates all groups and use the resulting string as the value to sent to IoTHub.
-            // This example mimics the default behaviour and defines a group which matches the conplete value.
+
+            // Pattern is a regular expression, which is applied to the actual value of the
+            // property (here 'EndpointUrl').
+            // If this key is ommited (which is the default), then no regex matching is done
+            // at all, which improves performance.
+            // If the key is used you need to define groups in the regular expression.
+            // Publisher applies the regular expression and then concatenates all groups
+            // found and use the resulting string as the value in the JSON message to
+            //sent to IoTHub.
+            // This example mimics the default behaviour and defines a group,
+            // which matches the conplete value:
             "Pattern": "(.*)",
-            // Name allows you to use a shorter string as key in the JSON message sent to IoTHub. By default the key is the same as the property name (EndpointUrl in our case).
+            // Here some more exaples for 'Pattern' values and the generated result:
+            // "Pattern": "i=(.*)"
+            // defined for Defaults.NodeId.Pattern, will generate for the above sample
+            // a 'NodeId' value of '2058'to be sent by publisher
+            // "Pattern": "(i)=(.*)"
+            // defined for Defaults.NodeId.Pattern, will generate for the above sample
+            // a 'NodeId' value of 'i2058' to be sent by publisher
+
+            // Name allows you to use a shorter string as property name in the JSON message
+            // sent by publisher. By default the property name is unchanged and will be
+            // here 'EndpointUrl'.
+            // The 'Name' property could only be set in the 'Defaults' object to ensure
+            // all messages from publisher sent to IoTHub have a similar layout.
             "Name": "EndpointUrl"
+
         },
         "NodeId": {
             "Publish": true,
+
+            // If you set Defaults.NodeId.Name to "ni", then the "NodeId" key/value pair
+            // (from the above example) will change to:
+            //      "ni": "i=2058",
             "Name": "NodeId"
         },
 
-        // The MonitoredItem object is configuring the properties taken from the MonitoredItem OPC UA object.
+        // The MonitoredItem object is configuring the data taken from the MonitoredItem
+        // OPC UA object for published nodes.
         "MonitoredItem": {
-            // The 'Flat' key is only used in the 'MonitoredItem' and 'Value' object of this JSON. When set to true, then the properties configured here,
-            // will be added as top level keys to the JSON message. When set to false, the properties will be put in a object with name 'MonitoredItem' into the
-            // JSON message.
+
+            // If you set the Defaults.MonitoredItem.Flat to 'false', then a
+            // 'MonitoredItem' object will appear, which contains 'ApplicationUri'
+            // and 'DisplayNode' proerties:
+            //      "NodeId": "i=2058",
+            //      "MonitoredItem": {
+            //          "ApplicationUri": "urn:myopcserver",
+            //          "DisplayName": "CurrentTime",
+            //      }
+            // The 'Flat' property could only be used for the 'MonitoredItem' and
+            // 'Value' configuratíon settings of the 'Defaults' objet and will be used
+            // for all JSON messages sent by publisher.
             "Flat": true,
+
             "ApplicationUri": {
                 "Publish": true,
                 "Name": "ApplicationUri"
@@ -42,10 +93,20 @@
                 "Name": "DisplayName"
             }
         },
-        // The Value object is configuring the properties taken from the event object the OPC UA stack provided in the value change notification event.
+        // The Value object is configuring the properties taken from the event object
+        // the OPC UA stack provided in the value change notification event.
         "Value": {
-            // 'Flat' is here set to false, which will result in an 'Value' object created in the JSON message, which has contains the properties configured below.
+            // If you set the Defaults.Value.Flat to 'true', then the 'Value'
+            // object will disappear completely and the 'Value' and 'SourceTimestamp'
+            // members won't be nested:
+            //      "DisplayName": "CurrentTime",
+            //      "Value": "10.11.2017 14:03:17",
+            //      "SourceTimestamp": "2017-11-10 14:03:17Z"
+            // The 'Flat' property could only be used for the 'MonitoredItem' and 'Value'
+            // configuratíon settings of the 'Defaults' objet and will be used for all JSON
+            // messages sent by publisher.
             "Flat": false,
+
             "Value": {
                 "Publish": true,
                 "Name": "Value"
@@ -56,7 +117,6 @@
             },
             // StatusCode is the 32 bit OPC UA status code formatted as hexadezimal number.
             "StatusCode": {
-                // 'Publish' is false, which means 'StatusCode' will not be part of the JSON message.
                 "Publish": false,
                 "Name": "StatusCode"
             },
@@ -67,57 +127,61 @@
             }
         }
     },
-    {
-        // In this object we configure the telemetry, which is generated for all notification we get from the endpoint specified
-        // be the key 'ForEndpointUrl'. The value of this key, is typically an endpoint URL configured in the publishednodes.json configuration file.
-        "ForEndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
-        "EndpointUrl": {
-            // We overwrite the default behaviour and publish the endpoint URL in this case.
-            "Publish": true,
-            // We also do not use 'EndpointUrl' as key, but save payload in the ingested message and just use 'eu'
-            "Name": "eu"
-        },
-        "NodeId": {
-            // We are not interested in the configured 'NodeId' value, so we do not publish it.
-            "Publish": false
-        },
-        "MonitoredItem": {
-            "Flat": false,
-            "ApplicationUri": {
-                // We already publish the endpoint URL, so we do not need the ApplicationUri of the MonitoredItem to be published.
+
+    // The next object allows to configure 'Publish' and 'Pattern' settings for specific
+    // endpoint URLs. Those will overwrite the settings specified in the 'Defaults' object
+    // or the default settings used by publisher.
+    // It is not allowed to specify 'Name' and 'Flat' properties in this object.
+    "EndpointSpecific": [
+        // The following shows how a endpoint specific configuration could look like:
+        {
+            // 'ForEndpointUrl' allows to configure for which OPC UA server this
+            // object applies and is a required property for all objects in the
+            // 'EndpointSpecific' array.
+            // The value of 'ForEndpointUrl' must be an 'EndpointUrl' configured in
+            // the publishednodes.json confguration file.
+            "ForEndpointUrl": "opc.tcp://<your_opcua_server>:<your_opcua_server_port>/<your_opcua_server_path>",
+            "EndpointUrl": {
+                // We overwrite the default behaviour and publish the
+                // endpoint URL in this case.
+                "Publish": true,
+                // We are only interested in the URL part following the 'opc.tcp://' prefix
+                // and define a group matching this.
+                "Pattern": "opc.tcp://(.*)"
+            },
+            "NodeId": {
+                // We are not interested in the configured 'NodeId' value, 
+                // so we do not publish it.
                 "Publish": false
+                // No 'Pattern' key is specified here, so the 'NodeId' value will be
+                // taken as specified in the publishednodes configuration file.
             },
-            "DisplayName": {
-                "Publish": true,
-                // Our server is configured to hold enough identification information in the DisplayName (which is the OPC UA nodeId if --fd is not used).
-                // But we are only interested in the meaningful part of the actual DisplayName property, so we define a regex which defines a group for this part
-                // of the DisplayName we are interested in.
-                "Pattern": "ns=.;s=(.*)",
-                // We optimize for minimal JSON message size and use a short key
-                "Name": "dn"
-            }
-        },
-        "Value": {
-            // We have no need for a 'Value' object in the JSON message and go for a completley flat JSON message sent to IoTHub.
-            "Flat": true,
-            "Name": "Value",
+            "MonitoredItem": {
+                "ApplicationUri": {
+                    // We already publish the endpoint URL, so we do not want
+                    //the ApplicationUri of the MonitoredItem to be published.
+                    "Publish": false
+                },
+                "DisplayName": {
+                    "Publish": true
+                }
+            },
             "Value": {
-                // The value of the node is important for us, everything else we are not interested in to keep the data ingest as small as possible.
-                "Publish": true,
-                "Name": "Value"
-            },
-            "SourceTimestamp": {
-                "Publish": false,
-                "Name": "SourceTimestamp"
-            },
-            "StatusCode": {
-                "Publish": false,
-                "Name": "StatusCode"
-            },
-            "Status": {
-                "Publish": false,
-                "Name": "Status"
+                "Value": {
+                    // The value of the node is important for us, everything else we
+                    //are not interested in to keep the data ingest as small as possible.
+                    "Publish": true
+                },
+                "SourceTimestamp": {
+                    "Publish": false
+                },
+                "StatusCode": {
+                    "Publish": false
+                },
+                "Status": {
+                    "Publish": false
+                }
             }
         }
-    }
-]
+    ]
+}


### PR DESCRIPTION
This change:
- Allows OpcPublisher to be use as a module in IoT Edge
- Adds configuration options to control the telemetry ingested to IoTHub/EdgeHub
- Adds a configuration option to allow to connect to server endpoints without security