### PR TITLE
Allow to specify device connection string via commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The syntax of the configuration file is as follows:
                     "MonitoredItem": {
                         "ApplicationUri": {
                             // We already publish the endpoint URL, so we do not want
-                            //the ApplicationUri of the MonitoredItem to be published.
+                            // the ApplicationUri of the MonitoredItem to be published.
                             "Publish": false
                         },
                         "DisplayName": {

--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ The complete usage of the application can be shown using the `--help` command li
                                        iothubmessagesize parameter controls when
                                        telemetry is sent.
                                        Default: '10'
+              --dc, --deviceconnectionstring=VALUE
+                                     if publisher is not able to register itself with
+                                       IoTHub, you could create a device with name <
+                                       applicationname> manually and pass in the
+                                       connectionstring of this device.
+                                       Default: none
               --lf, --logfile=VALUE  the filename of the logfile to use.
                                        Default: './Logs/<applicationname>.log.txt'
               --pn, --portnum=VALUE  the server port of the publisher OPC server

--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -214,8 +214,13 @@ namespace OpcPublisher
                                 return false;
                             }
                         }
+                        else
+                        {
+                            Trace($"There have been a device connectionstring specified on command line. Skipping device creation in IoTHub. Please ensure you created a device with name '{ApplicationName}' manually.");
+                        }
                     }
 
+                    // save the device connectionstring, if we have one
                     if (!string.IsNullOrEmpty(_deviceConnectionString))
                     {
                         Trace($"Adding device connectionstring to secure store.");

--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -234,8 +234,8 @@ namespace OpcPublisher
                     // connect to IoTHub
                     if (!string.IsNullOrEmpty(_deviceConnectionString))
                     {
-                        Trace($"Create Publisher IoTHub client with device connection string: '{deviceConnectionString}' using '{IotHubProtocol}' for communication.");
-                        _iotHubClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, IotHubProtocol);
+                        Trace($"Create Publisher IoTHub client with device connection string using '{IotHubProtocol}' for communication.");
+                        _iotHubClient = DeviceClient.CreateFromConnectionString(_deviceConnectionString, IotHubProtocol);
                         _iotHubClient.ProductInfo = "OpcPublisher";
                         ExponentialBackoff exponentialRetryPolicy = new ExponentialBackoff(int.MaxValue, TimeSpan.FromMilliseconds(2), TimeSpan.FromMilliseconds(1024), TimeSpan.FromMilliseconds(3));
                         _iotHubClient.SetRetryPolicy(exponentialRetryPolicy);

--- a/src/IotHubMessaging.cs
+++ b/src/IotHubMessaging.cs
@@ -209,7 +209,7 @@ namespace OpcPublisher
                             }
                             else
                             {
-                                Trace($"Could not register ourselves with IoT Hub.");
+                                Trace($"Can not register ourselves with IoT Hub.");
                                 Trace("exiting...");
                                 return false;
                             }
@@ -243,7 +243,7 @@ namespace OpcPublisher
                     }
                     else
                     {
-                        Trace("Device connection string not found in secure store. Please pass it in at least once via command line option. Could not connect to IoTHub.");
+                        Trace("Device connection string not found in secure store. Please pass it in at least once via command line option. Can not connect to IoTHub.");
                         Trace("exiting...");
                         return false;
                     }
@@ -367,7 +367,7 @@ namespace OpcPublisher
                 EndpointTelemetryConfiguration telemetryConfiguration = GetEndpointTelemetryConfiguration(messageData.EndpointUrl);
 
                 // currently the pattern processing is done in MonitoredItem_Notification of OpcSession.cs. In case of perf issues
-                // it could be also done here, the risk is then to lose messages in the communication queue.
+                // it can be also done here, the risk is then to lose messages in the communication queue.
 
                 // apply configured patterns to message data
                 // messageData.ApplyPatterns(telemetryConfiguration);

--- a/src/OpcSession.cs
+++ b/src/OpcSession.cs
@@ -301,7 +301,7 @@ namespace OpcPublisher
                 }
 
                 // currently the pattern processing is done here, which adds runtime to the notification processing.
-                // In case of perf issues it could be also done in CreateJsonMessage of IoTHubMessaging.cs.
+                // In case of perf issues it can be also done in CreateJsonMessage of IoTHubMessaging.cs.
 
                 // apply patterns
                 messageData.ApplyPatterns(telemetryConfiguration);
@@ -646,7 +646,7 @@ namespace OpcPublisher
                                     int namespaceIndex = GetNamespaceIndex(item.ConfigExpandedNodeId?.NamespaceUri);
                                     if (namespaceIndex < 0)
                                     {
-                                        Trace($"The namespace URI of node '{item.ConfigExpandedNodeId.ToString()}' could be not mapped to a namespace index.");
+                                        Trace($"The namespace URI of node '{item.ConfigExpandedNodeId.ToString()}' can be not mapped to a namespace index.");
                                     }
                                     else
                                     {
@@ -658,7 +658,7 @@ namespace OpcPublisher
                                     string namespaceUri = GetNamespaceUri(item.ConfigNodeId.NamespaceIndex);
                                     if (string.IsNullOrEmpty(namespaceUri))
                                     {
-                                        Trace($"The namespace index of node '{item.ConfigNodeId.ToString()}' is invalid and the node format could not be updated.");
+                                        Trace($"The namespace index of node '{item.ConfigNodeId.ToString()}' is invalid and the node format can not be updated.");
                                     }
                                     else
                                     {
@@ -1005,7 +1005,7 @@ namespace OpcPublisher
                     return;
                 }
 
-                // check if there is already a subscription with the same publishing interval, which could be used to monitor the node
+                // check if there is already a subscription with the same publishing interval, which can be used to monitor the node
                 OpcSubscription opcSubscription = OpcSubscriptions.FirstOrDefault(s => s.RequestedPublishingInterval == opcPublishingInterval);
                 
                 // if there was none found, create one

--- a/src/OpcStackConfiguration.cs
+++ b/src/OpcStackConfiguration.cs
@@ -225,7 +225,7 @@ namespace OpcPublisher
                     null,
                     null
                     );
-                _configuration.SecurityConfiguration.ApplicationCertificate.Certificate = certificate ?? throw new Exception("OPC UA application certificate could not be created! Cannot continue without it!");
+                _configuration.SecurityConfiguration.ApplicationCertificate.Certificate = certificate ?? throw new Exception("OPC UA application certificate can not be created! Cannot continue without it!");
             }
             else
             {
@@ -291,7 +291,7 @@ namespace OpcPublisher
                     ICertificateStore store = _configuration.SecurityConfiguration.TrustedPeerCertificates.OpenStore();
                     if (store == null)
                     {
-                        Trace($"Could not open trusted peer store. StorePath={_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
+                        Trace($"Can not open trusted peer store. StorePath={_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
                     }
                     else
                     {
@@ -309,7 +309,7 @@ namespace OpcPublisher
                 }
                 catch (Exception e)
                 {
-                    Trace(e, $"Could not add publisher certificate to trusted peer store. StorePath={_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
+                    Trace(e, $"Can not add publisher certificate to trusted peer store. StorePath={_configuration.SecurityConfiguration.TrustedPeerCertificates.StorePath}");
                 }
             }
             else

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -129,7 +129,7 @@ namespace OpcPublisher
                             }
                         }
                     },
-                    { "dc|deviceconnectionstring=", $"if publisher is not able to register itself with IoTHub, you could create a device with name <applicationname> manually and pass in the connectionstring of this device.\nDefault: none",
+                    { "dc|deviceconnectionstring=", $"if publisher is not able to register itself with IoTHub, you can create a device with name <applicationname> manually and pass in the connectionstring of this device.\nDefault: none",
                         (string dc) => DeviceConnectionString = dc
                     },
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -129,6 +129,9 @@ namespace OpcPublisher
                             }
                         }
                     },
+                    { "dc|deviceconnectionstring=", $"if publisher is not able to register itself with IoTHub, you could create a device with name <applicationname> manually and pass in the connectionstring of this device.\nDefault: none",
+                        (string dc) => DeviceConnectionString = dc
+                    },
 
                     // opc server configuration options
                     { "lf|logfile=", $"the filename of the logfile to use.\nDefault: './Logs/<applicationname>.log.txt'", (string l) => LogFileName = l },

--- a/src/SecureIoTHubToken.cs
+++ b/src/SecureIoTHubToken.cs
@@ -130,7 +130,7 @@ namespace OpcPublisher
                 else
                 {
                     rsa.Dispose();
-                    throw new CryptographicException("Could not encrypt IoTHub security token using generated public key!");
+                    throw new CryptographicException("Can not encrypt IoTHub security token using generated public key!");
                 }
             }
             rsa.Dispose();

--- a/src/telemetryconfiguration.json
+++ b/src/telemetryconfiguration.json
@@ -53,7 +53,7 @@
             // Name allows you to use a shorter string as property name in the JSON message
             // sent by publisher. By default the property name is unchanged and will be
             // here 'EndpointUrl'.
-            // The 'Name' property could only be set in the 'Defaults' object to ensure
+            // The 'Name' property can only be set in the 'Defaults' object to ensure
             // all messages from publisher sent to IoTHub have a similar layout.
             "Name": "EndpointUrl"
 
@@ -79,7 +79,7 @@
             //          "ApplicationUri": "urn:myopcserver",
             //          "DisplayName": "CurrentTime",
             //      }
-            // The 'Flat' property could only be used for the 'MonitoredItem' and
+            // The 'Flat' property can only be used for the 'MonitoredItem' and
             // 'Value' configuratíon settings of the 'Defaults' objet and will be used
             // for all JSON messages sent by publisher.
             "Flat": true,
@@ -102,7 +102,7 @@
             //      "DisplayName": "CurrentTime",
             //      "Value": "10.11.2017 14:03:17",
             //      "SourceTimestamp": "2017-11-10T14:03:17Z"
-            // The 'Flat' property could only be used for the 'MonitoredItem' and 'Value'
+            // The 'Flat' property can only be used for the 'MonitoredItem' and 'Value'
             // configuratíon settings of the 'Defaults' objet and will be used for all JSON
             // messages sent by publisher.
             "Flat": false,
@@ -134,7 +134,7 @@
     // or the default settings used by publisher.
     // It is not allowed to specify 'Name' and 'Flat' properties in this object.
     "EndpointSpecific": [
-        // The following shows how a endpoint specific configuration could look like:
+        // The following shows how a endpoint specific configuration can look like:
         {
             // 'ForEndpointUrl' allows to configure for which OPC UA server this
             // object applies and is a required property for all objects in the
@@ -151,7 +151,7 @@
                 "Pattern": "opc.tcp://(.*)"
             },
             "NodeId": {
-                // We are not interested in the configured 'NodeId' value, 
+                // We are not interested in the configured 'NodeId' value,
                 // so we do not publish it.
                 "Publish": false
                 // No 'Pattern' key is specified here, so the 'NodeId' value will be
@@ -160,7 +160,7 @@
             "MonitoredItem": {
                 "ApplicationUri": {
                     // We already publish the endpoint URL, so we do not want
-                    //the ApplicationUri of the MonitoredItem to be published.
+                    // the ApplicationUri of the MonitoredItem to be published.
                     "Publish": false
                 },
                 "DisplayName": {
@@ -170,7 +170,7 @@
             "Value": {
                 "Value": {
                     // The value of the node is important for us, everything else we
-                    //are not interested in to keep the data ingest as small as possible.
+                    // are not interested in to keep the data ingest as small as possible.
                     "Publish": true
                 },
                 "SourceTimestamp": {


### PR DESCRIPTION
this change allows to specify a device connection string via command line and there is no need to create a device in IoTHub. this is useful for environments which do not allow outbound HTTPS traffic.