### PR TITLE
Additional expanded node ids in json file

### DIFF
--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -873,11 +873,20 @@ namespace OpcPublisher
                     
                     if(messageData.AdditionalData != null)
                     {
+                        await _jsonWriter.WritePropertyNameAsync("AdditionalValues");
+                        await _jsonWriter.WriteStartArrayAsync();
                         foreach(var additionalData in messageData.AdditionalData)
                         {
-                            await _jsonWriter.WritePropertyNameAsync(additionalData.Key.Replace(" ", string.Empty));
+                            await _jsonWriter.WriteStartObjectAsync();
+                            await _jsonWriter.WritePropertyNameAsync("NodeId");
+                            await _jsonWriter.WriteValueAsync(additionalData.NodeId);
+                            await _jsonWriter.WritePropertyNameAsync("DisplayName");
+                            await _jsonWriter.WriteValueAsync(additionalData.DisplayName);
+                            await _jsonWriter.WritePropertyNameAsync("Value");
                             await _jsonWriter.WriteRawValueAsync(JsonConvert.SerializeObject(additionalData.Value));
+                            await _jsonWriter.WriteEndObjectAsync();
                         }
+                        await _jsonWriter.WriteEndArrayAsync();
                     }
 
                     await _jsonWriter.WriteEndObjectAsync();

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -290,14 +290,12 @@ namespace OpcPublisher
                         int samplingInterval = node.OpcSamplingInterval ?? OpcSamplingInterval;
                         if (isNodeIdFormat)
                         {
-                            //TODO => add additional node ids
                             // add the node info to the subscription with the default publishing interval, execute syncronously
                             Logger.Information($"PublishNodesMethod: Request to monitor item with NodeId '{nodeId.ToString()}' (PublishingInterval: {publishingInterval}, SamplingInterval: {samplingInterval})");
                             statusCode = await opcSession.AddNodeForMonitoringAsync(nodeId, null, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
                         }
                         else
                         {
-                            //TODO => add additional expanded node ids
                             // add the node info to the subscription with the default publishing interval, execute syncronously
                             Logger.Information($"PublishNodesMethod: Request to monitor item with ExpandedNodeId '{expandedNodeId.ToString()}' (PublishingInterval: {publishingInterval}, SamplingInterval: {samplingInterval})");
                             statusCode = await opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -293,14 +293,14 @@ namespace OpcPublisher
                             //TODO => add additional node ids
                             // add the node info to the subscription with the default publishing interval, execute syncronously
                             Logger.Information($"PublishNodesMethod: Request to monitor item with NodeId '{nodeId.ToString()}' (PublishingInterval: {publishingInterval}, SamplingInterval: {samplingInterval})");
-                            statusCode = await opcSession.AddNodeForMonitoringAsync(nodeId, null, null, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
+                            statusCode = await opcSession.AddNodeForMonitoringAsync(nodeId, null, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
                         }
                         else
                         {
                             //TODO => add additional expanded node ids
                             // add the node info to the subscription with the default publishing interval, execute syncronously
                             Logger.Information($"PublishNodesMethod: Request to monitor item with ExpandedNodeId '{expandedNodeId.ToString()}' (PublishingInterval: {publishingInterval}, SamplingInterval: {samplingInterval})");
-                            statusCode = await opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
+                            statusCode = await opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
                         }
                     }
                     catch (Exception e)

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -290,15 +290,17 @@ namespace OpcPublisher
                         int samplingInterval = node.OpcSamplingInterval ?? OpcSamplingInterval;
                         if (isNodeIdFormat)
                         {
+                            //TODO => add additional node ids
                             // add the node info to the subscription with the default publishing interval, execute syncronously
                             Logger.Information($"PublishNodesMethod: Request to monitor item with NodeId '{nodeId.ToString()}' (PublishingInterval: {publishingInterval}, SamplingInterval: {samplingInterval})");
-                            statusCode = await opcSession.AddNodeForMonitoringAsync(nodeId, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
+                            statusCode = await opcSession.AddNodeForMonitoringAsync(nodeId, null, null, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
                         }
                         else
                         {
+                            //TODO => add additional expanded node ids
                             // add the node info to the subscription with the default publishing interval, execute syncronously
                             Logger.Information($"PublishNodesMethod: Request to monitor item with ExpandedNodeId '{expandedNodeId.ToString()}' (PublishingInterval: {publishingInterval}, SamplingInterval: {samplingInterval})");
-                            statusCode = await opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
+                            statusCode = await opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, null, publishingInterval, samplingInterval, ShutdownTokenSource.Token);
                         }
                     }
                     catch (Exception e)

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -870,6 +870,16 @@ namespace OpcPublisher
                             await _jsonWriter.WriteEndObjectAsync();
                         }
                     }
+                    
+                    if(messageData.AdditionalData != null)
+                    {
+                        foreach(var additionalData in messageData.AdditionalData)
+                        {
+                            await _jsonWriter.WritePropertyNameAsync(additionalData.Key.Replace(" ", string.Empty));
+                            await _jsonWriter.WriteValueAsync(additionalData.Value);
+                        }
+                    }
+
                     await _jsonWriter.WriteEndObjectAsync();
                     await _jsonWriter.FlushAsync();
                 }

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -876,7 +876,7 @@ namespace OpcPublisher
                         foreach(var additionalData in messageData.AdditionalData)
                         {
                             await _jsonWriter.WritePropertyNameAsync(additionalData.Key.Replace(" ", string.Empty));
-                            await _jsonWriter.WriteValueAsync(additionalData.Value);
+                            await _jsonWriter.WriteRawValueAsync(JsonConvert.SerializeObject(additionalData.Value));
                         }
                     }
 

--- a/opcpublisher/OpcSession.cs
+++ b/opcpublisher/OpcSession.cs
@@ -241,10 +241,14 @@ namespace OpcPublisher
                     additionalNodeIdsDictionary = new Dictionary<string, object>();
                     foreach(var additionalExpandedNodeId in AdditionalExpandedNodeIds)
                     {
-                        var namespaceIndex = (ushort)monitoredItem.Subscription.Session.NamespaceUris.GetIndex(additionalExpandedNodeId.NamespaceUri);
+                        var namespaceIndex = additionalExpandedNodeId.NamespaceUri == null
+                            ? additionalExpandedNodeId.NamespaceIndex
+                            : (ushort)monitoredItem.Subscription.Session.NamespaceUris.GetIndex(additionalExpandedNodeId.NamespaceUri);
+
                         var nodeId = new NodeId(additionalExpandedNodeId.Identifier, namespaceIndex);
                         var nodeValue = monitoredItem.Subscription.Session.ReadValue(nodeId);
                         var node = monitoredItem.Subscription.Session.ReadNode(nodeId);
+                        
                         additionalNodeIdsDictionary[node.DisplayName.ToString()] = nodeValue.Value;
                     }
                 }

--- a/opcpublisher/OpcSession.cs
+++ b/opcpublisher/OpcSession.cs
@@ -52,6 +52,8 @@ namespace OpcPublisher
         public ExpandedNodeId ConfigExpandedNodeId { get; set; }
         public string OriginalId { get; set; }
         public OpcMonitoredItemConfigurationType ConfigType { get; set; }
+        public IEnumerable<ExpandedNodeId> AdditionalExpandedNodeIds { get; set; }
+        public IEnumerable<NodeId> AdditionalNodeIds { get; set; }
 
         /// <summary>
         /// Ctor using NodeId (ns syntax for namespace).
@@ -64,6 +66,8 @@ namespace OpcPublisher
             ConfigType = OpcMonitoredItemConfigurationType.NodeId;
             Init(sessionEndpointUrl);
             State = OpcMonitoredItemState.Unmonitored;
+            AdditionalExpandedNodeIds = null;
+            AdditionalNodeIds = null;
         }
 
         /// <summary>
@@ -77,6 +81,8 @@ namespace OpcPublisher
             ConfigType = OpcMonitoredItemConfigurationType.ExpandedNodeId;
             Init(sessionEndpointUrl);
             State = OpcMonitoredItemState.UnmonitoredNamespaceUpdateRequested;
+            AdditionalExpandedNodeIds = null;
+            AdditionalNodeIds = null;
         }
 
         /// <summary>

--- a/opcpublisher/OpcSession.cs
+++ b/opcpublisher/OpcSession.cs
@@ -54,7 +54,6 @@ namespace OpcPublisher
         public string OriginalId { get; set; }
         public OpcMonitoredItemConfigurationType ConfigType { get; set; }
         public IEnumerable<ExpandedNodeId> AdditionalExpandedNodeIds { get; set; }
-        public IEnumerable<NodeId> AdditionalNodeIds { get; set; }
 
         /// <summary>
         /// Ctor using NodeId (ns syntax for namespace).
@@ -68,7 +67,6 @@ namespace OpcPublisher
             Init(sessionEndpointUrl);
             State = OpcMonitoredItemState.Unmonitored;
             AdditionalExpandedNodeIds = null;
-            AdditionalNodeIds = null;
         }
 
         /// <summary>
@@ -83,7 +81,6 @@ namespace OpcPublisher
             Init(sessionEndpointUrl);
             State = OpcMonitoredItemState.UnmonitoredNamespaceUpdateRequested;
             AdditionalExpandedNodeIds = null;
-            AdditionalNodeIds = null;
         }
 
         /// <summary>
@@ -1096,8 +1093,7 @@ namespace OpcPublisher
         /// </summary>
         public async Task<HttpStatusCode> AddNodeForMonitoringAsync(
             NodeId nodeId, 
-            ExpandedNodeId expandedNodeId, 
-            IEnumerable<NodeId> additionalNodeIds, 
+            ExpandedNodeId expandedNodeId,
             IEnumerable<ExpandedNodeId> additionalExpandedNodeIds, 
             int opcPublishingInterval, 
             int opcSamplingInterval,
@@ -1146,10 +1142,7 @@ namespace OpcPublisher
                     // add a new item to monitor
                     if (expandedNodeId == null)
                     {
-                        opcMonitoredItem = new OpcMonitoredItem(nodeId, EndpointUrl)
-                        {
-                            AdditionalNodeIds = additionalNodeIds
-                        };
+                        opcMonitoredItem = new OpcMonitoredItem(nodeId, EndpointUrl);
                     }
                     else
                     {

--- a/opcpublisher/OpcSession.cs
+++ b/opcpublisher/OpcSession.cs
@@ -128,7 +128,7 @@ namespace OpcPublisher
                 }
                 if (expandedNodeId != null)
                 {
-                    if (ConfigExpandedNodeId.NamespaceUri != null && 
+                    if (ConfigExpandedNodeId.NamespaceUri != null &&
                         ConfigExpandedNodeId.NamespaceUri.Equals(expandedNodeId.NamespaceUri, StringComparison.OrdinalIgnoreCase) &&
                         ConfigExpandedNodeId.Identifier.ToString().Equals(expandedNodeId.Identifier.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
@@ -236,20 +236,27 @@ namespace OpcPublisher
 
                 Dictionary<string, object> additionalNodeIdsDictionary = null;
 
-                if(AdditionalExpandedNodeIds != null)
+                if (AdditionalExpandedNodeIds != null)
                 {
                     additionalNodeIdsDictionary = new Dictionary<string, object>();
-                    foreach(var additionalExpandedNodeId in AdditionalExpandedNodeIds)
+                    foreach (var additionalExpandedNodeId in AdditionalExpandedNodeIds)
                     {
-                        var namespaceIndex = additionalExpandedNodeId.NamespaceUri == null
-                            ? additionalExpandedNodeId.NamespaceIndex
-                            : (ushort)monitoredItem.Subscription.Session.NamespaceUris.GetIndex(additionalExpandedNodeId.NamespaceUri);
+                        try
+                        {
+                            var namespaceIndex = additionalExpandedNodeId.NamespaceUri == null
+                                ? additionalExpandedNodeId.NamespaceIndex
+                                : (ushort)monitoredItem.Subscription.Session.NamespaceUris.GetIndex(additionalExpandedNodeId.NamespaceUri);
 
-                        var nodeId = new NodeId(additionalExpandedNodeId.Identifier, namespaceIndex);
-                        var nodeValue = monitoredItem.Subscription.Session.ReadValue(nodeId);
-                        var node = monitoredItem.Subscription.Session.ReadNode(nodeId);
-                        
-                        additionalNodeIdsDictionary[node.DisplayName.ToString()] = nodeValue.Value;
+                            var nodeId = new NodeId(additionalExpandedNodeId.Identifier, namespaceIndex);
+                            var nodeValue = monitoredItem.Subscription.Session.ReadValue(nodeId);
+                            var node = monitoredItem.Subscription.Session.ReadNode(nodeId);
+
+                            additionalNodeIdsDictionary[node.DisplayName.ToString()] = nodeValue.Value;
+                        }
+                        catch(ServiceResultException ex)
+                        {
+                            Logger.Error(ex, "Error read additional data");
+                        }
                     }
                 }
 
@@ -828,7 +835,7 @@ namespace OpcPublisher
                             }
                             if (additionalMonitoredItemsCount % 10000 == 0)
                             {
-                                    Logger.Information($"Now monitoring {monitoredItemsCount + additionalMonitoredItemsCount} items in subscription with id '{opcSubscription.OpcUaClientSubscription.Id}'");
+                                Logger.Information($"Now monitoring {monitoredItemsCount + additionalMonitoredItemsCount} items in subscription with id '{opcSubscription.OpcUaClientSubscription.Id}'");
                             }
                             // request a config file update, if everything is successfully monitored
                             requestConfigFileUpdate = true;
@@ -1096,10 +1103,10 @@ namespace OpcPublisher
         /// one is created.
         /// </summary>
         public async Task<HttpStatusCode> AddNodeForMonitoringAsync(
-            NodeId nodeId, 
+            NodeId nodeId,
             ExpandedNodeId expandedNodeId,
-            IEnumerable<ExpandedNodeId> additionalExpandedNodeIds, 
-            int opcPublishingInterval, 
+            IEnumerable<ExpandedNodeId> additionalExpandedNodeIds,
+            int opcPublishingInterval,
             int opcSamplingInterval,
             CancellationToken ct)
         {
@@ -1114,7 +1121,7 @@ namespace OpcPublisher
 
                 // check if there is already a subscription with the same publishing interval, which can be used to monitor the node
                 OpcSubscription opcSubscription = OpcSubscriptions.FirstOrDefault(s => s.RequestedPublishingInterval == opcPublishingInterval);
-                
+
                 // if there was none found, create one
                 if (opcSubscription == null)
                 {
@@ -1340,10 +1347,10 @@ namespace OpcPublisher
             return false;
         }
 
-    /// <summary>
-    /// Shutdown the current session if it is connected.
-    /// </summary>
-    public async Task ShutdownAsync()
+        /// <summary>
+        /// Shutdown the current session if it is connected.
+        /// </summary>
+        public async Task ShutdownAsync()
         {
             bool sessionLocked = false;
             try

--- a/opcpublisher/OpcSession.cs
+++ b/opcpublisher/OpcSession.cs
@@ -246,8 +246,9 @@ namespace OpcPublisher
                     {
                         var namespaceIndex = (ushort)monitoredItem.Subscription.Session.NamespaceUris.GetIndex(additionalExpandedNodeId.NamespaceUri);
                         var nodeId = new NodeId(additionalExpandedNodeId.Identifier, namespaceIndex);
-                        var node = monitoredItem.Subscription.Session.ReadValue(nodeId);
-                        additionalNodeIdsDictionary[nodeId.ToString()] = node.Value;
+                        var nodeValue = monitoredItem.Subscription.Session.ReadValue(nodeId);
+                        var node = monitoredItem.Subscription.Session.ReadNode(nodeId);
+                        additionalNodeIdsDictionary[node.DisplayName.ToString()] = nodeValue.Value;
                     }
                 }
 

--- a/opcpublisher/OpcSession.cs
+++ b/opcpublisher/OpcSession.cs
@@ -222,6 +222,8 @@ namespace OpcPublisher
                     return;
                 }
 
+                var test = this.AdditionalExpandedNodeIds;
+
                 MonitoredItemNotification notification = args.NotificationValue as MonitoredItemNotification;
                 if (notification == null)
                 {
@@ -1074,7 +1076,14 @@ namespace OpcPublisher
         /// Adds a node to be monitored. If there is no subscription with the requested publishing interval,
         /// one is created.
         /// </summary>
-        public async Task<HttpStatusCode> AddNodeForMonitoringAsync(NodeId nodeId, ExpandedNodeId expandedNodeId, int opcPublishingInterval, int opcSamplingInterval, CancellationToken ct)
+        public async Task<HttpStatusCode> AddNodeForMonitoringAsync(
+            NodeId nodeId, 
+            ExpandedNodeId expandedNodeId, 
+            IEnumerable<NodeId> additionalNodeIds, 
+            IEnumerable<ExpandedNodeId> additionalExpandedNodeIds, 
+            int opcPublishingInterval, 
+            int opcSamplingInterval,
+            CancellationToken ct)
         {
             bool sessionLocked = false;
             try
@@ -1119,11 +1128,17 @@ namespace OpcPublisher
                     // add a new item to monitor
                     if (expandedNodeId == null)
                     {
-                        opcMonitoredItem = new OpcMonitoredItem(nodeId, EndpointUrl);
+                        opcMonitoredItem = new OpcMonitoredItem(nodeId, EndpointUrl)
+                        {
+                            AdditionalExpandedNodeIds = additionalExpandedNodeIds
+                        };
                     }
                     else
                     {
-                        opcMonitoredItem = new OpcMonitoredItem(expandedNodeId, EndpointUrl);
+                        opcMonitoredItem = new OpcMonitoredItem(expandedNodeId, EndpointUrl)
+                        {
+                            AdditionalNodeIds = additionalNodeIds
+                        };
                     }
                     opcMonitoredItem.RequestedSamplingInterval = opcSamplingInterval;
                     opcSubscription.OpcMonitoredItems.Add(opcMonitoredItem);

--- a/opcpublisher/PublisherNodeConfiguration.cs
+++ b/opcpublisher/PublisherNodeConfiguration.cs
@@ -285,7 +285,7 @@ namespace OpcPublisher
                                 {
                                     RequestedSamplingInterval = nodeInfo.OpcSamplingInterval,
                                     SamplingInterval = nodeInfo.OpcSamplingInterval,
-                                    AdditionalNodeIds = nodeInfo.AdditionalNodeIds
+                                    AdditionalExpandedNodeIds = nodeInfo.AdditionalExpandedNodeIds
                                 };
                                 opcSubscription.OpcMonitoredItems.Add(opcMonitoredItem);
                                 Interlocked.Increment(ref NodeConfigVersion);
@@ -570,7 +570,6 @@ namespace OpcPublisher
         public NodeId NodeId;
         public ExpandedNodeId ExpandedNodeId;
         public List<ExpandedNodeId> AdditionalExpandedNodeIds;
-        public List<NodeId> AdditionalNodeIds;
         public string OriginalId;
         public int OpcSamplingInterval;
         public int OpcPublishingInterval;
@@ -578,7 +577,6 @@ namespace OpcPublisher
         public NodePublishingConfiguration(ExpandedNodeId expandedNodeId, IEnumerable<ExpandedNodeId> additionalExpandedNodeIds, string originalId, Uri endpointUrl, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
         {
             NodeId = null;
-            AdditionalNodeIds = null;
             ExpandedNodeId = expandedNodeId;
             AdditionalExpandedNodeIds = additionalExpandedNodeIds?.ToList();
             OriginalId = originalId;
@@ -588,10 +586,9 @@ namespace OpcPublisher
             OpcPublishingInterval = opcPublishingInterval;
         }
 
-        public NodePublishingConfiguration(NodeId nodeId, IEnumerable<NodeId> additionalNodeIds, string originalId, Uri endpointUrl, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
+        public NodePublishingConfiguration(NodeId nodeId, string originalId, Uri endpointUrl, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
         {
             NodeId = nodeId;
-            AdditionalNodeIds = additionalNodeIds?.ToList();
             ExpandedNodeId = null;
             AdditionalExpandedNodeIds = null;
             OriginalId = originalId;

--- a/opcpublisher/PublisherNodeConfiguration.cs
+++ b/opcpublisher/PublisherNodeConfiguration.cs
@@ -271,7 +271,8 @@ namespace OpcPublisher
                                 OpcMonitoredItem opcMonitoredItem = new OpcMonitoredItem(nodeInfo.ExpandedNodeId, opcSession.EndpointUrl)
                                 {
                                     RequestedSamplingInterval = nodeInfo.OpcSamplingInterval,
-                                    SamplingInterval = nodeInfo.OpcSamplingInterval
+                                    SamplingInterval = nodeInfo.OpcSamplingInterval,
+                                    AdditionalExpandedNodeIds = nodeInfo.AdditionalExpandedNodeIds
                                 };
                                 opcSubscription.OpcMonitoredItems.Add(opcMonitoredItem);
                                 Interlocked.Increment(ref NodeConfigVersion);
@@ -282,7 +283,8 @@ namespace OpcPublisher
                                 OpcMonitoredItem opcMonitoredItem = new OpcMonitoredItem(nodeInfo.NodeId, opcSession.EndpointUrl)
                                 {
                                     RequestedSamplingInterval = nodeInfo.OpcSamplingInterval,
-                                    SamplingInterval = nodeInfo.OpcSamplingInterval
+                                    SamplingInterval = nodeInfo.OpcSamplingInterval,
+                                    AdditionalNodeIds = nodeInfo.AdditionalNodeIds
                                 };
                                 opcSubscription.OpcMonitoredItems.Add(opcMonitoredItem);
                                 Interlocked.Increment(ref NodeConfigVersion);

--- a/opcpublisher/PublisherNodeConfiguration.cs
+++ b/opcpublisher/PublisherNodeConfiguration.cs
@@ -177,7 +177,18 @@ namespace OpcPublisher
                                     if (opcNode.ExpandedNodeId != null)
                                     {
                                         ExpandedNodeId expandedNodeId = ExpandedNodeId.Parse(opcNode.ExpandedNodeId);
-                                        _nodePublishingConfiguration.Add(new NodePublishingConfiguration(expandedNodeId, opcNode.ExpandedNodeId, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
+                                        List<ExpandedNodeId> additionalExpandedNodeIds = null;
+
+                                        if(opcNode.AdditionalExpandedNodeIds != null)
+                                        {
+                                            additionalExpandedNodeIds = new List<ExpandedNodeId>();
+                                            foreach(string additionalExpandedNodeId in opcNode.AdditionalExpandedNodeIds)
+                                            {
+                                                additionalExpandedNodeIds.Add(ExpandedNodeId.Parse(additionalExpandedNodeId));
+                                            }
+                                        }
+
+                                        _nodePublishingConfiguration.Add(new NodePublishingConfiguration(expandedNodeId, additionalExpandedNodeIds, opcNode.ExpandedNodeId, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
                                     }
                                     else
                                     {
@@ -186,13 +197,13 @@ namespace OpcPublisher
                                         {
                                             // ExpandedNodeId format
                                             ExpandedNodeId expandedNodeId = ExpandedNodeId.Parse(opcNode.Id);
-                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(expandedNodeId, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
+                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(expandedNodeId, null, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
                                         }
                                         else
                                         {
                                             // NodeId format
                                             NodeId nodeId = NodeId.Parse(opcNode.Id);
-                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(nodeId, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
+                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(nodeId, null, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
                                         }
                                     }
                                 }
@@ -200,7 +211,7 @@ namespace OpcPublisher
                             else
                             {
                                 // NodeId (ns=) format node configuration syntax using default sampling and publishing interval.
-                                _nodePublishingConfiguration.Add(new NodePublishingConfiguration(publisherConfigFileEntryLegacy.NodeId, publisherConfigFileEntryLegacy.NodeId.ToString(), publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, OpcSamplingInterval, OpcPublishingInterval));
+                                _nodePublishingConfiguration.Add(new NodePublishingConfiguration(publisherConfigFileEntryLegacy.NodeId, null, publisherConfigFileEntryLegacy.NodeId.ToString(), publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, OpcSamplingInterval, OpcPublishingInterval));
                             }
                         }
                     }
@@ -511,6 +522,9 @@ namespace OpcPublisher
         public string ExpandedNodeId;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> AdditionalExpandedNodeIds;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public int? OpcSamplingInterval;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -551,14 +565,18 @@ namespace OpcPublisher
         public bool UseSecurity;
         public NodeId NodeId;
         public ExpandedNodeId ExpandedNodeId;
+        public List<ExpandedNodeId> AdditionalExpandedNodeIds;
+        public List<NodeId> AdditionalNodeIds;
         public string OriginalId;
         public int OpcSamplingInterval;
         public int OpcPublishingInterval;
 
-        public NodePublishingConfiguration(ExpandedNodeId expandedNodeId, string originalId, Uri endpointUrl, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
+        public NodePublishingConfiguration(ExpandedNodeId expandedNodeId, IEnumerable<ExpandedNodeId> additionalExpandedNodeIds, string originalId, Uri endpointUrl, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
         {
             NodeId = null;
+            AdditionalNodeIds = null;
             ExpandedNodeId = expandedNodeId;
+            AdditionalExpandedNodeIds = additionalExpandedNodeIds?.ToList();
             OriginalId = originalId;
             EndpointUrl = endpointUrl;
             UseSecurity = useSecurity ?? true;
@@ -566,10 +584,12 @@ namespace OpcPublisher
             OpcPublishingInterval = opcPublishingInterval;
         }
 
-        public NodePublishingConfiguration(NodeId nodeId, string originalId, Uri endpointUrl, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
+        public NodePublishingConfiguration(NodeId nodeId, IEnumerable<NodeId> additionalNodeIds, string originalId, Uri endpointUrl, bool? useSecurity, int opcSamplingInterval, int opcPublishingInterval)
         {
             NodeId = nodeId;
+            AdditionalNodeIds = additionalNodeIds?.ToList();
             ExpandedNodeId = null;
+            AdditionalExpandedNodeIds = null;
             OriginalId = originalId;
             EndpointUrl = endpointUrl;
             UseSecurity = useSecurity ?? true;

--- a/opcpublisher/PublisherNodeConfiguration.cs
+++ b/opcpublisher/PublisherNodeConfiguration.cs
@@ -174,19 +174,20 @@ namespace OpcPublisher
                                 // new node configuration syntax.
                                 foreach (var opcNode in publisherConfigFileEntryLegacy.OpcNodes)
                                 {
+                                    List<ExpandedNodeId> additionalExpandedNodeIds = null;
+
+                                    if(opcNode.AdditionalExpandedNodeIds != null)
+                                    {
+                                        additionalExpandedNodeIds = new List<ExpandedNodeId>();
+                                        foreach(string additionalExpandedNodeId in opcNode.AdditionalExpandedNodeIds)
+                                        {
+                                            additionalExpandedNodeIds.Add(ExpandedNodeId.Parse(additionalExpandedNodeId));
+                                        }
+                                    }
+
                                     if (opcNode.ExpandedNodeId != null)
                                     {
                                         ExpandedNodeId expandedNodeId = ExpandedNodeId.Parse(opcNode.ExpandedNodeId);
-                                        List<ExpandedNodeId> additionalExpandedNodeIds = null;
-
-                                        if(opcNode.AdditionalExpandedNodeIds != null)
-                                        {
-                                            additionalExpandedNodeIds = new List<ExpandedNodeId>();
-                                            foreach(string additionalExpandedNodeId in opcNode.AdditionalExpandedNodeIds)
-                                            {
-                                                additionalExpandedNodeIds.Add(ExpandedNodeId.Parse(additionalExpandedNodeId));
-                                            }
-                                        }
 
                                         _nodePublishingConfiguration.Add(new NodePublishingConfiguration(expandedNodeId, additionalExpandedNodeIds, opcNode.ExpandedNodeId, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
                                     }
@@ -197,13 +198,13 @@ namespace OpcPublisher
                                         {
                                             // ExpandedNodeId format
                                             ExpandedNodeId expandedNodeId = ExpandedNodeId.Parse(opcNode.Id);
-                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(expandedNodeId, null, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
+                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(expandedNodeId, additionalExpandedNodeIds, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
                                         }
                                         else
                                         {
                                             // NodeId format
                                             NodeId nodeId = NodeId.Parse(opcNode.Id);
-                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(nodeId, null, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
+                                            _nodePublishingConfiguration.Add(new NodePublishingConfiguration(nodeId, additionalExpandedNodeIds, opcNode.Id, publisherConfigFileEntryLegacy.EndpointUrl, publisherConfigFileEntryLegacy.UseSecurity, opcNode.OpcSamplingInterval ?? OpcSamplingInterval, opcNode.OpcPublishingInterval ?? OpcPublishingInterval));
                                         }
                                     }
                                 }

--- a/opcpublisher/PublisherNodeConfiguration.cs
+++ b/opcpublisher/PublisherNodeConfiguration.cs
@@ -358,6 +358,7 @@ namespace OpcPublisher
                                             opcNodeOnEndpoint.Id = monitoredItem.OriginalId;
                                             opcNodeOnEndpoint.OpcPublishingInterval = subscription.RequestedPublishingInterval == OpcPublishingInterval ? (int?)null : subscription.RequestedPublishingInterval;
                                             opcNodeOnEndpoint.OpcSamplingInterval = monitoredItem.RequestedSamplingInterval == OpcSamplingInterval ? (int?)null : monitoredItem.RequestedSamplingInterval;
+                                            opcNodeOnEndpoint.AdditionalExpandedNodeIds = monitoredItem.AdditionalExpandedNodeIds?.Select(nodeId => nodeId.ToString())?.ToList();
                                             publisherConfigurationFileEntry.OpcNodes.Add(opcNodeOnEndpoint);
                                         }
                                     }

--- a/opcpublisher/PublisherNodeManager.cs
+++ b/opcpublisher/PublisherNodeManager.cs
@@ -534,14 +534,12 @@ namespace OpcPublisher
 
                 if (isNodeIdFormat)
                 {
-                    //TODO => add additional node ids
                     // add the node info to the subscription with the default publishing interval, execute syncronously
                     Logger.Debug($"PublishNode: Request to monitor item with NodeId '{nodeId.ToString()}' (PublishingInterval: {OpcPublishingInterval}, SamplingInterval: {OpcSamplingInterval})");
                     statusCode = opcSession.AddNodeForMonitoringAsync(nodeId, null, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
                 }
                 else
                 {
-                    //TODO => add additional expanded node ids
                     // add the node info to the subscription with the default publishing interval, execute syncronously
                     Logger.Debug($"PublishNode: Request to monitor item with ExpandedNodeId '{expandedNodeId.ToString()}' (PublishingInterval: {OpcPublishingInterval}, SamplingInterval: {OpcSamplingInterval})");
                     statusCode = opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;

--- a/opcpublisher/PublisherNodeManager.cs
+++ b/opcpublisher/PublisherNodeManager.cs
@@ -534,15 +534,17 @@ namespace OpcPublisher
 
                 if (isNodeIdFormat)
                 {
+                    //TODO => add additional node ids
                     // add the node info to the subscription with the default publishing interval, execute syncronously
                     Logger.Debug($"PublishNode: Request to monitor item with NodeId '{nodeId.ToString()}' (PublishingInterval: {OpcPublishingInterval}, SamplingInterval: {OpcSamplingInterval})");
-                    statusCode = opcSession.AddNodeForMonitoringAsync(nodeId, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
+                    statusCode = opcSession.AddNodeForMonitoringAsync(nodeId, null, null, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
                 }
                 else
                 {
+                    //TODO => add additional expanded node ids
                     // add the node info to the subscription with the default publishing interval, execute syncronously
                     Logger.Debug($"PublishNode: Request to monitor item with ExpandedNodeId '{expandedNodeId.ToString()}' (PublishingInterval: {OpcPublishingInterval}, SamplingInterval: {OpcSamplingInterval})");
-                    statusCode = opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
+                    statusCode = opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
                 }
             }
             catch (Exception e)

--- a/opcpublisher/PublisherNodeManager.cs
+++ b/opcpublisher/PublisherNodeManager.cs
@@ -537,14 +537,14 @@ namespace OpcPublisher
                     //TODO => add additional node ids
                     // add the node info to the subscription with the default publishing interval, execute syncronously
                     Logger.Debug($"PublishNode: Request to monitor item with NodeId '{nodeId.ToString()}' (PublishingInterval: {OpcPublishingInterval}, SamplingInterval: {OpcSamplingInterval})");
-                    statusCode = opcSession.AddNodeForMonitoringAsync(nodeId, null, null, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
+                    statusCode = opcSession.AddNodeForMonitoringAsync(nodeId, null, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
                 }
                 else
                 {
                     //TODO => add additional expanded node ids
                     // add the node info to the subscription with the default publishing interval, execute syncronously
                     Logger.Debug($"PublishNode: Request to monitor item with ExpandedNodeId '{expandedNodeId.ToString()}' (PublishingInterval: {OpcPublishingInterval}, SamplingInterval: {OpcSamplingInterval})");
-                    statusCode = opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
+                    statusCode = opcSession.AddNodeForMonitoringAsync(null, expandedNodeId, null, OpcPublishingInterval, OpcSamplingInterval, ShutdownTokenSource.Token).Result;
                 }
             }
             catch (Exception e)

--- a/opcpublisher/publishednodes.json
+++ b/opcpublisher/publishednodes.json
@@ -47,6 +47,15 @@
                 "ExpandedNodeId": "nsu=http://opcfoundation.org/UA/;i=2258",
                 // the OPC sampling interval to use for this node.
                 "OpcSamplingInterval": 1000
+            },      
+            // Publisher will request the server at EndpointUrl to sample the node with the given additional expanded node ids.
+            // The subscription will publish the node value with additional node information.      
+            {
+                "ExpandedNodeId": "nsu=http://opcfoundation.org/UA/;i=2258",
+                // The list of additional information to add to the message sent to the IoT Hub
+                "AdditionalExpandedNodeIds":[
+                    "nsu=http://opcfoundation.org/UA/;i=2260"
+                ]
             }
         ]
     },

--- a/opcpublisher/publishednodes.json
+++ b/opcpublisher/publishednodes.json
@@ -54,7 +54,7 @@
                 "ExpandedNodeId": "nsu=http://opcfoundation.org/UA/;i=2258",
                 // The list of additional information to add to the message sent to the IoT Hub
                 "AdditionalExpandedNodeIds":[
-                    "nsu=http://opcfoundation.org/UA/;i=2260"
+                    "nsu=http://opcfoundation.org/UA/;i=2261"
                 ]
             }
         ]


### PR DESCRIPTION
The goal of this Pull Request is to add the possibility of adding additional information when we subscribe to a node item. 

We have added a parameter in the the publishednodes.json configuration file where we can define a list of additional nodes that we want to be passed along the subscribed node. 

An example of usage would be two correlated values, one changing frequently and the other rarely. But we want to always receive both values because they only make sense when they are together.