### PR TITLE
Change the way how the worker task for session creation and node moni…

### DIFF
--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -306,6 +306,12 @@ namespace OpcPublisher
                         Logger.Error(e, $"{logPrefix} Exception while trying to configure publishing node '{(isNodeIdFormat ? nodeId.ToString() : expandedNodeId.ToString())}'");
                         return (new MethodResponse((int)HttpStatusCode.InternalServerError));
                     }
+
+                    // stop when we encounter a problem
+                    if (statusCode != HttpStatusCode.OK && statusCode != HttpStatusCode.Accepted)
+                    {
+                        break;
+                    }
                 }
             }
             catch (AggregateException e)
@@ -406,13 +412,13 @@ namespace OpcPublisher
 
                         if (isNodeIdFormat)
                         {
-                            // stop monitoring the node, execute syncronously
+                            // stop monitoring the node, execute synchronously
                             Logger.Information($"{logPrefix} Request to stop monitoring item with NodeId '{nodeId.ToString()}')");
                             statusCode = await opcSession.RequestMonitorItemRemovalAsync(nodeId, null, ShutdownTokenSource.Token);
                         }
                         else
                         {
-                            // stop monitoring the node, execute syncronously
+                            // stop monitoring the node, execute synchronously
                             Logger.Information($"{logPrefix} Request to stop monitoring item with ExpandedNodeId '{expandedNodeId.ToString()}')");
                             statusCode = await opcSession.RequestMonitorItemRemovalAsync(null, expandedNodeId, ShutdownTokenSource.Token);
                         }


### PR DESCRIPTION
…toring is started and signaled. This fixes an issue if a high number of nodes is published via IoTHub direct methods, which earlier has blocked execution of the app.