### PR TITLE
Support IoTEdgeHubDev simulator as host

### DIFF
--- a/opcpublisher/IotEdgeHubCommunication.cs
+++ b/opcpublisher/IotEdgeHubCommunication.cs
@@ -22,7 +22,8 @@ namespace OpcPublisher
                     !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IOTEDGE_MODULEGENERATIONID")) &&
                     !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IOTEDGE_WORKLOADURI")) &&
                     !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IOTEDGE_DEVICEID")) &&
-                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IOTEDGE_MODULEID")));
+                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IOTEDGE_MODULEID"))) ||
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("EdgeHubConnectionString"));
         }
 
         /// <summary>


### PR DESCRIPTION
EdgeHubConnectionString environment variable is set by IoTEdgeHubDev tooling
to pass CS to a module.  Without it publisher fails to start under simulation.

Fix: Check for environment variable to be present and thus declare it to be
running int edge context.

The ModuleClient.CreateFromEnvironmentVariable will first check the
EdgeHubConnectionString environment variable before using the individual
variables thus the simple check for it to be defined will cause the module
client to be used.  Thus no more work needed.