### PR TITLE
Support listing published nodes with namespace information using OPC …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@
 *.exe
 /src/out
 /src/Logs
+/**/launchsettings.json
 
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ An example for the format of the configuration file is:
 
 ### Configuration via OPC UA method calls
 OPC Publisher has an OPC UA Server integrated, which can be accessed on port 62222. If the hostname is `publisher`, then the URI of the endpoint is: `opc.tcp://publisher:62222/UA/Publisher`
-This endpoint exposes four methods:
+This endpoint exposes five methods:
   - PublishNode
   - UnpublishNode
   - GetPublishedNodes
+  - GetConfiguredEndpoints (see below)
+  - GetConfiguredNodesOnEndpoint (see below)
 
 ### Configuration via IoTHub direct function calls
 OPC Publisher implements the following IoTHub direct method calls, which can be called when OPC Publisher runs standalone or in IoT Edge:

--- a/opcpublisher/Diagnostics.cs
+++ b/opcpublisher/Diagnostics.cs
@@ -132,12 +132,10 @@ namespace OpcPublisher
             return diagnosticLogMethodResponseModel;
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// Fetch diagnostic startup log data.
         /// </summary>
-        public static async Task<DiagnosticLogMethodResponseModel> GetDiagnosticStartupLogAsync()
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        public static Task<DiagnosticLogMethodResponseModel> GetDiagnosticStartupLogAsync()
         {
             DiagnosticLogMethodResponseModel diagnosticLogMethodResponseModel = new DiagnosticLogMethodResponseModel();
             diagnosticLogMethodResponseModel.MissedMessageCount = 0;
@@ -159,7 +157,7 @@ namespace OpcPublisher
                 diagnosticLogMethodResponseModel.Log.Add("Diagnostic log is disabled. Please use --di to enable it.");
             }
 
-            return diagnosticLogMethodResponseModel;
+            return Task.FromResult(diagnosticLogMethodResponseModel);
         }
 
         /// <summary>

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -852,7 +852,7 @@ namespace OpcPublisher
         /// <summary>
         /// Handle method call to get list of configured nodes on a specific endpoint.
         /// </summary>
-        static async Task<MethodResponse> HandleGetConfiguredNodesOnEndpointMethodAsync(MethodRequest methodRequest, object userContext)
+        static internal async Task<MethodResponse> HandleGetConfiguredNodesOnEndpointMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleGetConfiguredNodesOnEndpointMethodAsync:";
             Uri endpointUri = null;

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -191,7 +191,7 @@ namespace OpcPublisher
         /// <summary>
         /// Handle publish node method call.
         /// </summary>
-        static async Task<MethodResponse> HandlePublishNodesMethodAsync(MethodRequest methodRequest, object userContext)
+        static internal async Task<MethodResponse> HandlePublishNodesMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandlePublishNodesMethodAsync:";
             Uri endpointUri = null;
@@ -383,7 +383,7 @@ namespace OpcPublisher
         /// <summary>
         /// Handle unpublish node method call.
         /// </summary>
-        static async Task<MethodResponse> HandleUnpublishNodesMethodAsync(MethodRequest methodRequest, object userContext)
+        static internal async Task<MethodResponse> HandleUnpublishNodesMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleUnpublishNodesMethodAsync:";
             NodeId nodeId = null;
@@ -582,7 +582,7 @@ namespace OpcPublisher
         /// <summary>
         /// Handle unpublish all nodes method call.
         /// </summary>
-        static async Task<MethodResponse> HandleUnpublishAllNodesMethodAsync(MethodRequest methodRequest, object userContext)
+        static internal async Task<MethodResponse> HandleUnpublishAllNodesMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleUnpublishAllNodesMethodAsync:";
             Uri endpointUri = null;
@@ -709,7 +709,7 @@ namespace OpcPublisher
                 {
                     break;
                 }
-            };
+            }
             if (maxIndex != statusResponse.Count())
             {
                 statusResponse.RemoveRange(maxIndex, statusResponse.Count() - maxIndex);
@@ -729,12 +729,10 @@ namespace OpcPublisher
             return methodResponse;
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// Handle method call to get all endpoints which published nodes.
         /// </summary>
-        static async Task<MethodResponse> HandleGetConfiguredEndpointsMethodAsync(MethodRequest methodRequest, object userContext)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        static internal Task<MethodResponse> HandleGetConfiguredEndpointsMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleGetConfiguredEndpointsMethodAsync:";
             GetConfiguredEndpointsMethodRequestModel getConfiguredEndpointsMethodRequest = null;
@@ -804,7 +802,7 @@ namespace OpcPublisher
                         {
                             break;
                         }
-                    };
+                    }
                 }
             }
 
@@ -836,15 +834,13 @@ namespace OpcPublisher
             }
             MethodResponse methodResponse = new MethodResponse(result, (int)statusCode);
             Logger.Information($"{logPrefix} completed with result {statusCode.ToString()}");
-            return methodResponse;
+            return Task.FromResult(methodResponse);
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// Handle method call to get list of configured nodes on a specific endpoint.
         /// </summary>
-        static internal async Task<MethodResponse> HandleGetConfiguredNodesOnEndpointMethodAsync(MethodRequest methodRequest, object userContext)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        static internal Task<MethodResponse> HandleGetConfiguredNodesOnEndpointMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleGetConfiguredNodesOnEndpointMethodAsync:";
             Uri endpointUri = null;
@@ -940,7 +936,7 @@ namespace OpcPublisher
                             {
                                 break;
                             }
-                        };
+                        }
                     }
                 }
             }
@@ -977,15 +973,13 @@ namespace OpcPublisher
             }
             MethodResponse methodResponse = new MethodResponse(result, (int)statusCode);
             Logger.Information($"{logPrefix} completed with result {statusCode.ToString()}");
-            return methodResponse;
+            return Task.FromResult(methodResponse);
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// Handle method call to get diagnostic information.
         /// </summary>
-        static async Task<MethodResponse> HandleGetDiagnosticInfoMethodAsync(MethodRequest methodRequest, object userContext)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        static internal Task<MethodResponse> HandleGetDiagnosticInfoMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleGetDiagnosticInfoMethodAsync:";
             HttpStatusCode statusCode = HttpStatusCode.OK;
@@ -1025,13 +1019,13 @@ namespace OpcPublisher
             }
             MethodResponse methodResponse = new MethodResponse(result, (int)statusCode);
             Logger.Information($"{logPrefix} completed with result {statusCode.ToString()}");
-            return methodResponse;
+            return Task.FromResult(methodResponse);
         }
 
         /// <summary>
         /// Handle method call to get log information.
         /// </summary>
-        static async Task<MethodResponse> HandleGetDiagnosticLogMethodAsync(MethodRequest methodRequest, object userContext)
+        static internal async Task<MethodResponse> HandleGetDiagnosticLogMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleGetDiagnosticLogMethodAsync:";
             HttpStatusCode statusCode = HttpStatusCode.OK;
@@ -1077,7 +1071,7 @@ namespace OpcPublisher
         /// <summary>
         /// Handle method call to get log information.
         /// </summary>
-        static async Task<MethodResponse> HandleGetDiagnosticStartupLogMethodAsync(MethodRequest methodRequest, object userContext)
+        static internal async Task<MethodResponse> HandleGetDiagnosticStartupLogMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleGetDiagnosticStartupLogMethodAsync:";
             HttpStatusCode statusCode = HttpStatusCode.OK;
@@ -1120,12 +1114,10 @@ namespace OpcPublisher
             return methodResponse;
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// Handle method call to get log information.
         /// </summary>
-        static async Task<MethodResponse> HandleExitApplicationMethodAsync(MethodRequest methodRequest, object userContext)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        static internal Task<MethodResponse> HandleExitApplicationMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleExitApplicationMethodAsync:";
             HttpStatusCode statusCode = HttpStatusCode.OK;
@@ -1152,7 +1144,7 @@ namespace OpcPublisher
                 try
                 {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                    Task.Run(async () => await ExitApplicationAsync(exitApplicationMethodRequest.SecondsTillExit).ConfigureAwait(false));
+                    Task.Run(async () => await ExitApplicationAsync(exitApplicationMethodRequest.SecondsTillExit));
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     statusMessage = $"Module will exit in {exitApplicationMethodRequest.SecondsTillExit} seconds";
                     Logger.Information($"{logPrefix} {statusMessage}");
@@ -1179,15 +1171,13 @@ namespace OpcPublisher
             }
             MethodResponse methodResponse = new MethodResponse(result, (int)statusCode);
             Logger.Information($"{logPrefix} completed with result {statusCode.ToString()}");
-            return methodResponse;
+            return Task.FromResult(methodResponse);
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// Handle method call to get application information.
         /// </summary>
-        static async Task<MethodResponse> HandleGetInfoMethodAsync(MethodRequest methodRequest, object userContext)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        static internal Task<MethodResponse> HandleGetInfoMethodAsync(MethodRequest methodRequest, object userContext)
         {
             string logPrefix = "HandleGetInfoMethodAsync:";
             GetInfoMethodResponseModel getInfoMethodResponseModel = new GetInfoMethodResponseModel();
@@ -1234,15 +1224,13 @@ namespace OpcPublisher
             }
             MethodResponse methodResponse = new MethodResponse(result, (int)statusCode);
             Logger.Information($"{logPrefix} completed with result {statusCode.ToString()}");
-            return methodResponse;
+            return Task.FromResult(methodResponse);
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        /// </summary>
+        /// <summary>
         /// Method that is called for any unimplemented call. Just returns that info to the caller
         /// </summary>
-        private async Task<MethodResponse> DefaultMethodHandlerAsync(MethodRequest methodRequest, object userContext)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        private Task<MethodResponse> DefaultMethodHandlerAsync(MethodRequest methodRequest, object userContext)
         {
             Logger.Information($"Received direct method call for {methodRequest.Name}, which is not implemented");
             string response = $"Method {methodRequest.Name} successfully received, but this method is not implemented";
@@ -1250,15 +1238,13 @@ namespace OpcPublisher
             string resultString = JsonConvert.SerializeObject(response);
             byte[] result = Encoding.UTF8.GetBytes(resultString);
             MethodResponse methodResponse = new MethodResponse(result, (int)HttpStatusCode.OK);
-            return methodResponse;
+            return Task.FromResult(methodResponse);
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// Initializes internal message processing.
         /// </summary>
-        public static async Task<bool> InitMessageProcessingAsync()
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        public static Task<bool> InitMessageProcessingAsync()
         {
             try
             {
@@ -1273,12 +1259,12 @@ namespace OpcPublisher
 
                 Logger.Information("Creating task process and batch monitored item data updates...");
                 _monitoredItemsProcessorTask = Task.Run(async () => await MonitoredItemsProcessorAsync(_shutdownToken).ConfigureAwait(false), _shutdownToken);
-                return true;
+                return Task.FromResult(true);
             }
             catch (Exception e)
             {
                 Logger.Error(e, "Failure initializing message processing.");
-                return false;
+                return Task.FromResult(false);
             }
         }
 
@@ -1737,7 +1723,7 @@ namespace OpcPublisher
                 {
                     break;
                 }
-            };
+            }
             if (maxIndex != statusResponse.Count())
             {
                 statusResponse.RemoveRange(maxIndex, statusResponse.Count() - maxIndex);

--- a/opcpublisher/PublisherNodeManager.cs
+++ b/opcpublisher/PublisherNodeManager.cs
@@ -114,9 +114,12 @@ namespace OpcPublisher
 
                     MethodState getPublishedNodesLegacyMethod = CreateMethod(methodsFolder, "GetPublishedNodes", "GetPublishedNodes");
                     SetGetPublishedNodesLegacyMethodProperties(ref getPublishedNodesLegacyMethod);
+                    
+                    MethodState getConfiguredNodesOnEndpointMethod = CreateMethod(methodsFolder, "GetConfiguredNodesOnEndpoint", "GetConfiguredNodesOnEndpoint");
+                    SetGetConfiguredNodesOnEndpointMethodProperties(ref getConfiguredNodesOnEndpointMethod);
 
-                    MethodState getPublishedNodes2Method = CreateMethod(methodsFolder, "GetConfiguredNodesOnEndpoint", "GetConfiguredNodesOnEndpoint");
-                    SetGetConfiguredNodesOnEndpointMethodProperties(ref getPublishedNodes2Method);
+                    MethodState getGetConfiguredEndpointsMethod = CreateMethod(methodsFolder, "GetConfiguredEndpoints", "GetConfiguredEndpoints");
+                    SetGetConfiguredEndpointsMethodProperties(ref getGetConfiguredEndpointsMethod);
                 }
                 catch (Exception e)
                 {
@@ -260,6 +263,48 @@ namespace OpcPublisher
                 new Argument() { Name = "ResponseJson", Description = "Response model as json string.",  DataType = DataTypeIds.String, ValueRank = ValueRanks.Scalar }
             };
             method.OnCallMethod = new GenericMethodCalledEventHandler(OnGetConfiguredNodesOnEndpointCall);
+        }
+
+
+        /// <summary>
+        /// Sets properies of the GetConfiguredEndpoints method
+        /// </summary>
+        private void SetGetConfiguredEndpointsMethodProperties(ref MethodState method) 
+        {
+            // define input arguments
+            method.InputArguments = new PropertyState<Argument[]>(method)
+            {
+                NodeId = new NodeId(method.BrowseName.Name + "InArgs", NamespaceIndex),
+                BrowseName = BrowseNames.InputArguments
+            };
+            method.InputArguments.DisplayName = method.InputArguments.BrowseName.Name;
+            method.InputArguments.TypeDefinitionId = VariableTypeIds.PropertyType;
+            method.InputArguments.ReferenceTypeId = ReferenceTypeIds.HasProperty;
+            method.InputArguments.DataType = DataTypeIds.Argument;
+            method.InputArguments.ValueRank = ValueRanks.OneDimension;
+
+            method.InputArguments.Value = new Argument[]
+            {
+                new Argument() { Name = "RequestJson", Description = "Request model as json string.",  DataType = DataTypeIds.String, ValueRank = ValueRanks.Scalar }
+            };
+
+            // set output arguments
+            method.OutputArguments = new PropertyState<Argument[]>(method) 
+            {
+                NodeId = new NodeId(method.BrowseName.Name + "OutArgs", NamespaceIndex),
+                BrowseName = BrowseNames.OutputArguments
+            };
+            method.OutputArguments.DisplayName = method.OutputArguments.BrowseName.Name;
+            method.OutputArguments.TypeDefinitionId = VariableTypeIds.PropertyType;
+            method.OutputArguments.ReferenceTypeId = ReferenceTypeIds.HasProperty;
+            method.OutputArguments.DataType = DataTypeIds.Argument;
+            method.OutputArguments.ValueRank = ValueRanks.OneDimension;
+
+            method.OutputArguments.Value = new Argument[]
+            {
+                new Argument() { Name = "ResponseJson", Description = "Response model as json string.",  DataType = DataTypeIds.String, ValueRank = ValueRanks.Scalar }
+            };
+            method.OnCallMethod = new GenericMethodCalledEventHandler(OnGetConfiguredEndpointsCall);
         }
 
         /// <summary>
@@ -699,15 +744,32 @@ namespace OpcPublisher
         /// <summary>
         /// Handle method call to get list of configured nodes on a specific endpoint.
         /// </summary>
-        private ServiceResult OnGetConfiguredNodesOnEndpointCall(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
-        {
-            string logPrefix = "GetConfiguredNodesOnEndpoint:";
+        private ServiceResult OnGetConfiguredNodesOnEndpointCall(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments) {
+            string logPrefix = "GetConfiguredNodesOnEndpointCall:";
             try 
             {
                 var methodResult = HubCommunication.HandleGetConfiguredNodesOnEndpointMethodAsync(new Microsoft.Azure.Devices.Client.MethodRequest("GetConfiguredNodesOnEndpointMethod", Encoding.UTF8.GetBytes(inputArguments[0] as string)), null).Result;
                 outputArguments[0] = methodResult.ResultAsJson;
             }
-            catch (Exception ex)
+            catch (Exception ex) 
+            {
+                Logger.Error($"{logPrefix} The request is invalid!");
+                return ServiceResult.Create(ex, null, StatusCodes.Bad);
+            }
+            return ServiceResult.Good;
+        }
+
+        /// <summary>
+        /// Handle method call to get configured endpoints
+        /// </summary>
+        private ServiceResult OnGetConfiguredEndpointsCall(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments) {
+            string logPrefix = "GetConfiguredEndpointsCall:";
+            try 
+            {
+                var methodResult = HubCommunication.HandleGetConfiguredEndpointsMethodAsync(new Microsoft.Azure.Devices.Client.MethodRequest("GetConfiguredEndpointsMethod", Encoding.UTF8.GetBytes(inputArguments[0] as string)), null).Result;
+                outputArguments[0] = methodResult.ResultAsJson;
+            }
+            catch (Exception ex) 
             {
                 Logger.Error($"{logPrefix} The request is invalid!");
                 return ServiceResult.Create(ex, null, StatusCodes.Bad);

--- a/opcpublisher/PublisherNodeManager.cs
+++ b/opcpublisher/PublisherNodeManager.cs
@@ -115,8 +115,8 @@ namespace OpcPublisher
                     MethodState getPublishedNodesLegacyMethod = CreateMethod(methodsFolder, "GetPublishedNodes", "GetPublishedNodes");
                     SetGetPublishedNodesLegacyMethodProperties(ref getPublishedNodesLegacyMethod);
 
-                    MethodState getPublishedNodes2Method = CreateMethod(methodsFolder, "GetPublishedNodes2", "GetPublishedNodes2");
-                    SetGetPublishedNodes2MethodProperties(ref getPublishedNodes2Method);
+                    MethodState getPublishedNodes2Method = CreateMethod(methodsFolder, "GetConfiguredNodesOnEndpoint", "GetConfiguredNodesOnEndpoint");
+                    SetGetConfiguredNodesOnEndpointMethodProperties(ref getPublishedNodes2Method);
                 }
                 catch (Exception e)
                 {
@@ -224,7 +224,7 @@ namespace OpcPublisher
         /// <summary>
         /// Sets properies of the GetPublishedNodes method
         /// </summary>
-        private void SetGetPublishedNodes2MethodProperties(ref MethodState method) 
+        private void SetGetConfiguredNodesOnEndpointMethodProperties(ref MethodState method) 
         {
             // define input arguments
             method.InputArguments = new PropertyState<Argument[]>(method)
@@ -240,7 +240,7 @@ namespace OpcPublisher
 
             method.InputArguments.Value = new Argument[]
             {
-                new Argument() { Name = "MethodRequest", Description = "New method request json.",  DataType = DataTypeIds.String, ValueRank = ValueRanks.Scalar }
+                new Argument() { Name = "RequestJson", Description = "Request model as json string.",  DataType = DataTypeIds.String, ValueRank = ValueRanks.Scalar }
             };
 
             // set output arguments
@@ -257,9 +257,9 @@ namespace OpcPublisher
 
             method.OutputArguments.Value = new Argument[]
             {
-                new Argument() { Name = "MethodResponse", Description = "New method response json",  DataType = DataTypeIds.String, ValueRank = ValueRanks.Scalar }
+                new Argument() { Name = "ResponseJson", Description = "Response model as json string.",  DataType = DataTypeIds.String, ValueRank = ValueRanks.Scalar }
             };
-            method.OnCallMethod = new GenericMethodCalledEventHandler(OnGetPublishedNodes2Call);
+            method.OnCallMethod = new GenericMethodCalledEventHandler(OnGetConfiguredNodesOnEndpointCall);
         }
 
         /// <summary>
@@ -699,9 +699,9 @@ namespace OpcPublisher
         /// <summary>
         /// Handle method call to get list of configured nodes on a specific endpoint.
         /// </summary>
-        private ServiceResult OnGetPublishedNodes2Call(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
+        private ServiceResult OnGetConfiguredNodesOnEndpointCall(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
         {
-            string logPrefix = "OnGetPublishedNodesRestCall:";
+            string logPrefix = "GetConfiguredNodesOnEndpoint:";
             try 
             {
                 var methodResult = HubCommunication.HandleGetConfiguredNodesOnEndpointMethodAsync(new Microsoft.Azure.Devices.Client.MethodRequest("GetConfiguredNodesOnEndpointMethod", Encoding.UTF8.GetBytes(inputArguments[0] as string)), null).Result;
@@ -709,8 +709,8 @@ namespace OpcPublisher
             }
             catch (Exception ex)
             {
-                Logger.Error($"{logPrefix} The endpointUrl is invalid '{inputArguments[0] as string}'!");
-                return ServiceResult.Create(ex, null, StatusCodes.BadInvalidArgument);
+                Logger.Error($"{logPrefix} The request is invalid!");
+                return ServiceResult.Create(ex, null, StatusCodes.Bad);
             }
             return ServiceResult.Good;
         }

--- a/opcpublisher/PublisherNodeManager.cs
+++ b/opcpublisher/PublisherNodeManager.cs
@@ -157,7 +157,7 @@ namespace OpcPublisher
         }
 
         /// <summary>
-        /// Sets properies of the UnpublishNode method.
+        /// Sets properties of the UnpublishNode method.
         /// </summary>
         private void SetUnpublishNodeMethodProperties(ref MethodState method)
         {
@@ -183,7 +183,7 @@ namespace OpcPublisher
         }
 
         /// <summary>
-        /// Sets properies of the GetPublishedNodes method, which is only there for backward compatibility.
+        /// Sets properties of the GetPublishedNodes method, which is only there for backward compatibility.
         /// This method is acutally returning the configured nodes in NodeId syntax.
         /// </summary>
         private void SetGetPublishedNodesLegacyMethodProperties(ref MethodState method)
@@ -225,7 +225,7 @@ namespace OpcPublisher
         }
 
         /// <summary>
-        /// Sets properies of the GetPublishedNodes method
+        /// Sets properties of the GetConfiguredNodesOnEndpoint method
         /// </summary>
         private void SetGetConfiguredNodesOnEndpointMethodProperties(ref MethodState method) 
         {
@@ -267,7 +267,7 @@ namespace OpcPublisher
 
 
         /// <summary>
-        /// Sets properies of the GetConfiguredEndpoints method
+        /// Sets properties of the GetConfiguredEndpoints method
         /// </summary>
         private void SetGetConfiguredEndpointsMethodProperties(ref MethodState method) 
         {


### PR DESCRIPTION
…server

Since the existing Getnodes call only returns NodeId, whose namespace index
lives in a different server, add a new opc method that calls into the
existing and tested iot hub method to expose the new list format.