### PR TITLE
Allow AMQP as IoT Edge module, remove read of sampling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments
 
 # OPC Publisher
-This reference implementation demonstrates how to connect to existing OPC UA servers and publishes JSON encoded telemetry data from these servers in OPC UA "Pub/Sub" format (using a JSON payload) to Azure IoT Hub. All transport protocols supported by Azure IoT Edge can be used, i.e. HTTPS, AMQP and MQTT (the default).
+This reference implementation demonstrates how to connect to existing OPC UA servers and publishes JSON encoded telemetry data from these servers in OPC UA "Pub/Sub" format (using a JSON payload) to Azure IoT Hub. All transport protocols supported by the Azure IoTHub client SDK can be used, i.e. HTTPS, AMQP and MQTT (the default).
 
 This application, apart from including an OPC UA *client* for connecting to existing OPC UA servers you have on your network, also includes an OPC UA *server* on port 62222 that can be used to manage what gets published and offers IoTHub direct methods to do the same.
 
@@ -628,7 +628,8 @@ The right container for your OS and CPU architecture (if supported) will be auto
 
 ## Using it as a module in Azure IoT Edge
 OPC Publisher is ready to be used as a module to run in [Azure IoT Edge](https://docs.microsoft.com/en-us/azure/iot-edge) Microsoft's Intelligent Edge framework.
-We recommend to take a look on the information available on the beforementioned link and use then the information provided here.
+We recommend to take a look on the information available on the beforementioned link and use then the information provided here. When using
+OPC Publisher as IoT Edge module only Amqp_Tcp_Only and Mqtt_Tcp_Only (default) are supported as transport protocols.
 
 To add OPC Publisher as module to your IoT Edge deployment, you go to the Azure portal and navigate to your IoTHub and:
 * Go to IoT Edge and create or select your IoT Edge device.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments
 
 # OPC Publisher
-This reference implementation demonstrates how to connect to existing OPC UA servers and publishes JSON encoded telemetry data from these servers in OPC UA "Pub/Sub" format (using a JSON payload) to Azure IoT Hub. All transport protocols supported by the Azure IoTHub client SDK can be used, i.e. HTTPS, AMQP and MQTT (the default).
+This reference implementation demonstrates how to connect to existing OPC UA servers and publishes JSON encoded telemetry data from these servers in OPC UA "Pub/Sub" format (using a JSON payload) to Azure IoT Hub. All transport protocols supported by the Azure IoTHub client SDK can be used, i.e. HTTPS, AMQP and MQTT.
 
 This application, apart from including an OPC UA *client* for connecting to existing OPC UA servers you have on your network, also includes an OPC UA *server* on port 62222 that can be used to manage what gets published and offers IoTHub direct methods to do the same.
 
@@ -374,12 +374,14 @@ The complete usage of the application can be shown using the `--help` command li
               --ll, --loglevel=VALUE the loglevel to use (allowed: fatal, error, warn,
                                        info, debug, verbose).
                                        Default: info
-              --ih, --iothubprotocol=VALUE
-                                     the protocol to use for communication with Azure
-                                       IoTHub (allowed values: Amqp, Http1, Amqp_
-                                       WebSocket_Only, Amqp_Tcp_Only, Mqtt, Mqtt_
-                                       WebSocket_Only, Mqtt_Tcp_Only).
-                                       Default: Mqtt_WebSocket_Only
+               --ih, --iothubprotocol=VALUE
+                                      the protocol to use for communication with IoTHub (
+                                        allowed values: Amqp, Http1, Amqp_WebSocket_Only,
+                                         Amqp_Tcp_Only, Mqtt, Mqtt_WebSocket_Only, Mqtt_
+                                        Tcp_Only) or IoT EdgeHub (allowed values: Mqtt_
+                                        Tcp_Only, Amqp_Tcp_Only).
+                                        Default for IoTHub: Mqtt_WebSocket_Only
+                                        Default for IoT EdgeHub: Amqp_Tcp_Only
               --ms, --iothubmessagesize=VALUE
                                      the max size of a message which can be send to
                                        IoTHub. when telemetry of this size is available
@@ -629,7 +631,7 @@ The right container for your OS and CPU architecture (if supported) will be auto
 ## Using it as a module in Azure IoT Edge
 OPC Publisher is ready to be used as a module to run in [Azure IoT Edge](https://docs.microsoft.com/en-us/azure/iot-edge) Microsoft's Intelligent Edge framework.
 We recommend to take a look on the information available on the beforementioned link and use then the information provided here. When using
-OPC Publisher as IoT Edge module only Amqp_Tcp_Only and Mqtt_Tcp_Only (default) are supported as transport protocols.
+OPC Publisher as IoT Edge module only Amqp_Tcp_Only and Mqtt_Tcp_Only are supported as transport protocols.
 
 To add OPC Publisher as module to your IoT Edge deployment, you go to the Azure portal and navigate to your IoTHub and:
 * Go to IoT Edge and create or select your IoT Edge device.

--- a/opcpublisher/HubCommunication.cs
+++ b/opcpublisher/HubCommunication.cs
@@ -48,7 +48,9 @@ namespace OpcPublisher
 
         public static uint HubMessageSize { get; set; } = 262144;
 
-        public static TransportType HubProtocol { get; set; } = TransportType.Mqtt_WebSocket_Only;
+        public const TransportType IotHubProtocolDefault = TransportType.Mqtt_WebSocket_Only;
+        public const TransportType IotEdgeHubProtocolDefault = TransportType.Amqp_Tcp_Only;
+        public static TransportType HubProtocol { get; set; } = IotHubProtocolDefault;
 
         public static int DefaultSendIntervalSeconds { get; set; } = 10;
 

--- a/opcpublisher/IotEdgeHubCommunication.cs
+++ b/opcpublisher/IotEdgeHubCommunication.cs
@@ -41,10 +41,8 @@ namespace OpcPublisher
             try
             {
                 // connect to EdgeHub
-                HubProtocol = TransportType.Mqtt_Tcp_Only;
-                Logger.Information($"Create IoTEdgeHub module client using '{HubProtocol}' for communication.");
+                Logger.Information($"Protocol used for IoT EdgeHub communication is'{HubProtocol}'");
                 ModuleClient hubClient = await ModuleClient.CreateFromEnvironmentAsync(HubProtocol).ConfigureAwait(false);
-
                 if (await InitHubCommunicationAsync(hubClient, HubProtocol).ConfigureAwait(false))
                 {
                     return true;

--- a/opcpublisher/IotHubCommunication.cs
+++ b/opcpublisher/IotHubCommunication.cs
@@ -21,11 +21,6 @@ namespace OpcPublisher
         public static string IotDeviceCertX509StorePathDefault => "My";
 
         public static string IotHubOwnerConnectionString { get; set; } = null;
-        public static Microsoft.Azure.Devices.Client.TransportType IotHubProtocol
-        {
-            get => HubProtocol;
-            set => HubProtocol = value;
-        }
 
         public static string IotDeviceCertStoreType { get; set; } = CertificateStoreType.X509Store;
         public static string IotDeviceCertStorePath { get; set; } = IotDeviceCertX509StorePathDefault;
@@ -118,8 +113,9 @@ namespace OpcPublisher
                 }
 
                 // connect to IoTHub
-                DeviceClient hubClient = DeviceClient.CreateFromConnectionString(DeviceConnectionString, IotHubProtocol);
-                if (await InitHubCommunicationAsync(hubClient, IotHubProtocol).ConfigureAwait(false))
+                Logger.Information($"Protocol used for IoTHub communication is'{HubProtocol}'");
+                DeviceClient hubClient = DeviceClient.CreateFromConnectionString(DeviceConnectionString, HubProtocol);
+                if (await InitHubCommunicationAsync(hubClient, HubProtocol).ConfigureAwait(false))
                 {
                     return true;
                 }

--- a/opcpublisher/OpcSession.cs
+++ b/opcpublisher/OpcSession.cs
@@ -338,11 +338,6 @@ namespace OpcPublisher
                             {
                                 Logger.Information($"Namespace index {i++}: {ns}");
                             }
-
-                            // fetch the minimum supported item sampling interval from the server.
-                            DataValue minSupportedSamplingInterval = OpcUaClientSession.ReadValue(VariableIds.Server_ServerCapabilities_MinSupportedSampleRate);
-                            _minSupportedSamplingInterval = minSupportedSamplingInterval.GetValue(0);
-                            Logger.Information($"The server on endpoint '{selectedEndpoint.EndpointUrl}' supports a minimal sampling interval of {_minSupportedSamplingInterval} ms.");
                             State = SessionState.Connected;
                         }
                         else
@@ -1211,6 +1206,5 @@ namespace OpcPublisher
         private CancellationToken _sessionCancelationToken;
         private NamespaceTable _namespaceTable;
         private EndpointTelemetryConfiguration _telemetryConfiguration;
-        private double _minSupportedSamplingInterval;
     }
 }

--- a/opcpublisher/Program.cs
+++ b/opcpublisher/Program.cs
@@ -178,17 +178,14 @@ namespace OpcPublisher
                         // IoTHub specific options
                         { "ih|iothubprotocol=", $"{(IsIotEdgeModule ? "not supported when running as IoT Edge module\n" : $"the protocol to use for communication with Azure IoTHub (allowed values: {string.Join(", ", Enum.GetNames(IotHubProtocol.GetType()))}).\nDefault: {Enum.GetName(IotHubProtocol.GetType(), IotHubProtocol)}")}",
                             (Microsoft.Azure.Devices.Client.TransportType p) => {
+                                IotHubProtocol = p;
                                 if (IsIotEdgeModule)
                                 {
-                                    if (p != Microsoft.Azure.Devices.Client.TransportType.Mqtt_Tcp_Only)
+                                    if (p != Microsoft.Azure.Devices.Client.TransportType.Mqtt_Tcp_Only && p != Microsoft.Azure.Devices.Client.TransportType.Amqp_Tcp_Only)
                                     {
-                                        WriteLine("When running as IoTEdge module Mqtt_Tcp_Only is enforced.");
+                                        WriteLine("When running as IoTEdge module only Mqtt_Tcp_Only or Amqp_Tcp_Only are supported. Enforcing Mqtt_Tcp_Only");
                                         IotHubProtocol = Microsoft.Azure.Devices.Client.TransportType.Mqtt_Tcp_Only;
                                     }
-                                }
-                                else
-                                {
-                                    IotHubProtocol = p;
                                 }
                             }
                         },

--- a/opcpublisher/Program.cs
+++ b/opcpublisher/Program.cs
@@ -97,6 +97,9 @@ namespace OpcPublisher
                 if (IsIotEdgeModule)
                 {
                     WriteLine("IoTEdge detected.");
+
+                    // set IoT Edge specific defaults
+                    HubProtocol = IotEdgeHubProtocolDefault;
                 }
 
                 // command line options
@@ -176,15 +179,15 @@ namespace OpcPublisher
 
 
                         // IoTHub specific options
-                        { "ih|iothubprotocol=", $"{(IsIotEdgeModule ? "not supported when running as IoT Edge module\n" : $"the protocol to use for communication with Azure IoTHub (allowed values: {string.Join(", ", Enum.GetNames(IotHubProtocol.GetType()))}).\nDefault: {Enum.GetName(IotHubProtocol.GetType(), IotHubProtocol)}")}",
+                        { "ih|iothubprotocol=", $"the protocol to use for communication with IoTHub (allowed values: {$"{string.Join(", ", Enum.GetNames(HubProtocol.GetType()))}"}) or IoT EdgeHub (allowed values: Mqtt_Tcp_Only, Amqp_Tcp_Only).\nDefault for IoTHub: {IotHubProtocolDefault}\nDefault for IoT EdgeHub: {IotEdgeHubProtocolDefault}",
                             (Microsoft.Azure.Devices.Client.TransportType p) => {
-                                IotHubProtocol = p;
+                                HubProtocol = p;
                                 if (IsIotEdgeModule)
                                 {
                                     if (p != Microsoft.Azure.Devices.Client.TransportType.Mqtt_Tcp_Only && p != Microsoft.Azure.Devices.Client.TransportType.Amqp_Tcp_Only)
                                     {
-                                        WriteLine("When running as IoTEdge module only Mqtt_Tcp_Only or Amqp_Tcp_Only are supported. Enforcing Mqtt_Tcp_Only");
-                                        IotHubProtocol = Microsoft.Azure.Devices.Client.TransportType.Mqtt_Tcp_Only;
+                                        WriteLine("When running as IoTEdge module only Mqtt_Tcp_Only or Amqp_Tcp_Only are supported. Using Amqp_Tcp_Only");
+                                        HubProtocol = IotEdgeHubProtocolDefault;
                                     }
                                 }
                             }


### PR DESCRIPTION
This change:
- allows also Ampq_Tcp_Only as transport when running as IoT Edge module
- removes a OPC UA server call to read the minimal supported sampling interval, since some OPC UA servers do not support this variable and it had no functional impact