### PR TITLE
Bugfix for automatically updating node configuration file.

### DIFF
--- a/opcpublisher/PublisherNodeConfiguration.cs
+++ b/opcpublisher/PublisherNodeConfiguration.cs
@@ -20,6 +20,11 @@ namespace OpcPublisher
     public class PublisherNodeConfiguration : IPublisherNodeConfiguration, IDisposable
     {
         /// <summary>
+        /// Keeps the version of the node configuration that has lastly been persisted
+        /// </summary>
+        private uint _lastNodeConfigVersion;
+
+        /// <summary>
         /// Name of the node configuration file.
         /// </summary>
         public static string PublisherNodeConfigurationFilename { get; set; } = $"{System.IO.Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}publishednodes.json";
@@ -687,10 +692,15 @@ namespace OpcPublisher
         /// </summary>
         public async Task UpdateNodeConfigurationFileAsync()
         {
+            if (NodeConfigVersion == _lastNodeConfigVersion)
+                return;
+
             try
             {
-                // itereate through all sessions, subscriptions and monitored items and create config file entries
+                // iterate through all sessions, subscriptions and monitored items and create config file entries
                 List<PublisherConfigurationFileEntryModel> publisherNodeConfiguration = GetPublisherConfigurationFileEntries(null, true, out uint nodeConfigVersion);
+
+                Logger.Debug($"Update node configuration file, version: {_lastNodeConfigVersion:X8}");
 
                 // update the config file
                 try


### PR DESCRIPTION
The configuration file did not get updated when the session has been closed (e.g. 0 monitored subscriptions are left) due to the behavior regarding the cancellation token in method OpcSession.ConnectAndMonitorAsync.
This fix will also solve the following issue:
[opc publisher 2.4.1 leaves entries in node configuration file after unpublishing all nodes](https://github.com/Azure/iot-edge-opc-publisher/issues/249)
